### PR TITLE
v0.2.1: README badges, Disclaimer, v0.2.0 callout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # presence
 
+[![CI](https://github.com/sara-star-quant/presence/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/sara-star-quant/presence/actions/workflows/ci.yml)
+[![Latest release](https://img.shields.io/github/v/release/sara-star-quant/presence?sort=semver)](https://github.com/sara-star-quant/presence/releases)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Python 3.12+](https://img.shields.io/badge/python-3.12%20%7C%203.13%20%7C%203.14-blue)](.github/workflows/ci.yml)
+[![Stdlib only](https://img.shields.io/badge/runtime-stdlib--only-success)](pyproject.toml)
+[![Local only](https://img.shields.io/badge/state-local--only-success)](docs/security.md)
+
 A Claude Code plugin that turns every session into part of a continuum.
 
 `presence` adds four things to Claude Code, globally, with one install and zero per-project setup:
@@ -11,6 +18,8 @@ A Claude Code plugin that turns every session into part of a continuum.
 
 State lives in `~/.claude/presence/`, fully local, never uploaded.
 
+> **New in v0.2.0**: the `zerotrust` preset is fully shipped: AES-GCM at-rest encryption with the data key in your OS keychain, a tamper-evident audit log with per-line SHA-256 hash chain, SessionStart fail-closed integrity check, and a `/presence-unlock` flow gating settings writes. See [`docs/zerotrust.md`](docs/zerotrust.md).
+
 ## Install
 
 ### Via marketplace (once published)
@@ -21,8 +30,6 @@ State lives in `~/.claude/presence/`, fully local, never uploaded.
 ```
 
 ### Local install
-
-> Available once the repo is pushed publicly to GitHub.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/sara-star-quant/presence/main/install.sh | bash
@@ -37,6 +44,14 @@ git clone https://github.com/sara-star-quant/presence ~/code/presence
 
 The installer symlinks the plugin into `~/.claude/plugins/presence` and creates the state directory at `~/.claude/presence/`. It is idempotent.
 
+For the Zero-Trust preset's at-rest encryption, also install the `cryptography` library:
+
+```bash
+pip install --user cryptography
+```
+
+Default presets are stdlib-only; `cryptography` is opt-in.
+
 ## Verify install
 
 In any Claude Code session:
@@ -45,7 +60,11 @@ In any Claude Code session:
 /presence-status
 ```
 
-You should see your active preset, the project ID for the current repo, and the size of the model + telemetry stores.
+You should see your active preset, the project ID for the current repo, and the size of the model + telemetry stores. For a focused Zero-Trust checklist:
+
+```
+/presence-status --zerotrust
+```
 
 ## Presets
 
@@ -58,16 +77,16 @@ You should see your active preset, the project ID for the current repo, and the 
 /presence-preset use zerotrust
 ```
 
-| Preset | Model | Telemetry | Commit gate | Stop gate |
-|---|---|---|---|---|
-| `solo-dev` (default) | on, terse | on, no PR check | off (advisory only via Stop) | silent (logged, surfaced next session) |
-| `team-oss` | on, verbose | on, optional PR check | warn (advisory text injected) | silent |
-| `enterprise-strict` | on, verbose, audit | on, audit log | block (refuses commit) | block (re-prompts on unverified success) |
-| `zerotrust` | on, audit | on, audit, no PR check | block | block |
+| Preset | Model | Telemetry | Commit gate | Stop gate | At rest |
+|---|---|---|---|---|---|
+| `solo-dev` (default) | on, terse | on, no PR check | off (advisory only via Stop) | silent (logged, surfaced next session) | plain |
+| `team-oss` | on, verbose | on, optional PR check | warn (advisory text injected) | silent | plain |
+| `enterprise-strict` | on, verbose, audit | on, audit log | block (refuses commit) | block (re-prompts on unverified success) | plain |
+| `zerotrust` | on, encrypted, audit | on, encrypted, audit, no PR check | block | block | AES-GCM + keychain |
 
 Custom presets: drop a `<name>.json` in `~/.claude/presence/presets/` and switch to it.
 
-See [`docs/zerotrust.md`](docs/zerotrust.md) for what the Zero-Trust preset adds and what is shipped vs planned.
+See [`docs/zerotrust.md`](docs/zerotrust.md) for the Zero-Trust profile in detail and [`CHANGELOG.md`](CHANGELOG.md) for the per-version diff.
 
 ## Uninstall
 
@@ -81,17 +100,36 @@ Or, for local install:
 ~/.claude/plugins/presence/install.sh --uninstall
 ```
 
-State at `~/.claude/presence/` is preserved by default. Pass `--purge` to also remove state.
+State at `~/.claude/presence/` is preserved by default. Pass `--purge` to also remove state. Under the Zero-Trust preset, also use `/presence-reset --crypto` to rotate the keychain key and wipe encrypted state.
 
 ## Privacy
 
 - All state is local. Nothing is ever uploaded.
 - No analytics, no telemetry-to-vendor, no remote calls.
 - The `outcome-check` skill makes one optional `gh` call to read PR status if `gh` is on `$PATH` and authenticated; this hits GitHub's API directly, not any third party. Disable in preset.
+- Under `zerotrust`, even that optional call is disabled.
 
 ## Architecture
 
-See [docs/architecture.md](docs/architecture.md) for the full design: what each hook does, how state is laid out, and how to write a custom preset.
+See [`docs/architecture.md`](docs/architecture.md) for the full design: what each hook does, how state is laid out, the XML context schema, and how to write a custom preset.
+
+## Disclaimer
+
+`presence` is provided **as is** under the [MIT License](LICENSE), without warranty of any kind, express or implied. The authors and copyright holders (Sara Star Quant LLC) and any contributors are **not responsible** for any damage, data loss, security incident, regression, lost productivity, or other adverse outcome arising from the installation or use of this plugin.
+
+This project is **not advice** of any kind:
+
+- **Not legal advice.** The security model documented in [`docs/security.md`](docs/security.md) and [`docs/zerotrust.md`](docs/zerotrust.md) is informational. It is not a compliance attestation, certification, or guarantee under any regulatory framework (GDPR, HIPAA, SOC 2, ISO 27001, etc.). If you operate in a regulated environment, consult qualified counsel before relying on this plugin's properties.
+- **Not security advice.** The Zero-Trust preset reduces attack surface and adds layered controls (encryption at rest, audit log, fail-closed integrity, hard commit gates) but is **not** a substitute for proper threat modeling, penetration testing, or operational security review in your specific environment.
+- **Not engineering advice.** The calibrated-confidence gate and the living project model are useful nudges, **not** proofs of correctness. They reduce one common failure mode (asserting completion without verification); they do not replace tests, code review, or your own judgment.
+
+By installing or using `presence`, you accept full responsibility for:
+
+- Reviewing the source before running it on your system or in any session that touches sensitive data.
+- Verifying that the documented properties (no network egress, local-only state, redaction patterns, encryption format, etc.) actually match what your environment requires.
+- Any downstream consequences of decisions made or claims accepted while presence was active in your sessions, including but not limited to: code committed, code reverted, settings changed, and inferences drawn from the project model or telemetry digest.
+
+The full legal terms are in [LICENSE](LICENSE). This README's Disclaimer section is an informational summary of the spirit of those terms; in any conflict, the LICENSE controls.
 
 ## License
 


### PR DESCRIPTION
## Summary

Adds six status badges to the top of the README, a substantive Disclaimer section, and a v0.2.0 feature callout. No code changes.

## Changes

**Badges** (top of README; render once repo is public):
- CI status from GitHub Actions
- Latest release (semver-sorted)
- License (MIT)
- Python versions (3.12 / 3.13 / 3.14)
- Stdlib-only runtime
- Local-only state

**Disclaimer section** (new):
- 'as is' MIT, no warranty, no responsibility on authors / Sara Star Quant LLC
- Explicitly NOT advice (legal, security, or engineering)
- User accepts responsibility for source review, property verification, downstream consequences of decisions made while presence was active

**Other polish:**
- v0.2.0 callout under the four pillars block
- Presets table gains an "At rest" column noting the AES-GCM keychain story for zerotrust
- Install section mentions cryptography for ZT preset
- Verify-install section mentions /presence-status --zerotrust
- Uninstall section mentions /presence-reset --crypto
- Privacy section notes ZT disables even the optional gh PR call
- Removed stale "available once the repo is pushed publicly" note
- Linked CHANGELOG.md from the Presets section

## Test plan

- [x] Badge URLs use the canonical pattern (will render once repo is public; currently 404 because repo is private)
- [x] Disclaimer language matches the user's ask