### PR TITLE
v0.2.1: bump version + CHANGELOG entry (docs-only release)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "presence",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Continuous-collaboration layer for Claude Code: living project model, outcome telemetry, event digest, and calibrated confidence. Fully local, install-once, applies to every project.",
   "author": {
     "name": "Sara Star Quant LLC"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.2.1
+
+Documentation-only release.
+
+- README: added six status badges (CI, latest release, license, Python versions, stdlib-only runtime, local-only state).
+- README: added a Disclaimer section. 'as is' MIT, no warranty, no responsibility on authors / Sara Star Quant LLC, explicitly not legal/security/engineering advice. User accepts full responsibility for source review, property verification, and downstream consequences of decisions made while presence was active.
+- README: added v0.2.0 feature callout under the four pillars block.
+- README: presets table gains an 'At rest' column noting AES-GCM + keychain for the zerotrust preset.
+- README: install / verify / uninstall / privacy sections updated to reference v0.2.0 features (cryptography install hint for ZT, `/presence-status --zerotrust`, `/presence-reset --crypto`, ZT disabling the optional `gh` PR call).
+- README: linked CHANGELOG.md from the Presets section.
+
 ## v0.2.0
 
 The Zero-Trust preset becomes real: every control documented in `docs/zerotrust.md` is now implemented and tested.

--- a/MANIFEST.lock
+++ b/MANIFEST.lock
@@ -1,7 +1,7 @@
 {
   "_format": 1,
   "files": {
-    ".claude-plugin/plugin.json": "fadf105d3e2b1f78084ca56ae2903ce7d27a6c2b143a512a105a57438a5fb29e",
+    ".claude-plugin/plugin.json": "a63a605bebc8502fba54de7e97d821081ea9adee94095b4d15cb900b1f017ae7",
     "agents/model-curator.md": "1b8381997ea4c29944e1388b7467ca38787c893801e8bfd79460c103d0e169d5",
     "commands/presence-curate.md": "9295204486515a9dfd1a66ee77b64b067fdcb04ca436f182106659b33d504986",
     "commands/presence-doctor.md": "36bf525442fa906811f7a67b654c09b4254f961ea4953365a890aff1456e2398",


### PR DESCRIPTION
## Summary

Patch release for the README/Disclaimer changes that landed in #1 (docs-only). Bumps `plugin.json` from `0.2.0` to `0.2.1`, adds the corresponding CHANGELOG section, and refreshes `MANIFEST.lock`.

## Why this is a separate PR

PR #1 was merged before the version bump commit reached the branch, so the v0.2.1 bump didn't ride along. Cherry-picked the bump onto a fresh branch from current main; this PR carries it forward so `main` actually reflects v0.2.1 once merged.

## Changes

- `.claude-plugin/plugin.json`: version `0.2.0` -> `0.2.1`
- `CHANGELOG.md`: new `## v0.2.1` section above v0.2.0, summarizing the docs-only changes from PR #1
- `MANIFEST.lock`: regenerated (the version bump in plugin.json is in the manifest scope)

## Quality gates

- [x] 154 tests pass + 1 honest skip (Python 3.12 / 3.13 / 3.14)
- [x] ruff clean
- [x] shellcheck clean
- [x] MANIFEST.lock verifies OK