### PR TITLE
v0.4.2: cross-tool AGENTS.md adapter (closes roadmap issue #8)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "presence",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Continuous-collaboration layer for Claude Code: living project model, outcome telemetry, event digest, and calibrated confidence. Fully local, install-once, applies to every project.",
   "author": {
     "name": "Sara Star Quant LLC"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## v0.4.2
+
+Cross-tool AGENTS.md adapter. Closes roadmap issue #8 (multi-AI-tool support).
+
+The original v0.4.2 plan called for per-tool adapters (Cursor, Gemini, Codex, claude-code, clawbot, generic). Verification against current docs (April 2026) revealed that **AGENTS.md is now an open standard under the Agentic AI Foundation (Linux Foundation)**, read by Codex, Cursor, Gemini CLI, Windsurf, GitHub Copilot, and dozens of other tools. That collapses the design to **one adapter** that refreshes the project's `AGENTS.md` at Claude Code's SessionStart event, with a filename override for users who prefer a tool-specific name (`GEMINI.md`, `.cursor/rules/presence.mdc`, etc.).
+
+### Added
+
+- **`lib/adapters/agents_md.py`**: `AgentsMdAdapter`. Refreshes a delimited section (`<!-- presence:start --> ... <!-- presence:end -->`) of `<repo_root>/AGENTS.md` on `SessionStart` events. Idempotent; preserves user-authored content outside the markers; never raises (failed write is silent). Honors `PRESENCE_AGENTS_MD_FILENAME` for filename override (e.g., `GEMINI.md`, `.cursor/rules/presence.mdc`). Subdirectory paths in the override work; parent dirs are created.
+- **`lib/adapters/generic.py`**: `GenericAdapter`. Plain-text stdout for unknown / debug hosts. Useful when running presence outside Claude Code.
+- **`lib/adapters/__init__.py`**: `PRESENCE_HOST` env var dispatches between `claude` (default), `agents-md` (with `agents_md` and `agents` aliases), `generic`, and any unknown value (falls through to `ClaudeAdapter`).
+- **`docs/multi-host.md`** (new): full guide for the cross-tool flow. Hosts that read AGENTS.md (verified April 2026), the file-contract guarantees (idempotent, user-content-preserving, refresh-only-on-SessionStart), filename override examples, the should-I-commit-AGENTS.md tradeoff, and a comparison with MCP (v0.4.1).
+- **`docs/index.md`**: links to the new `multi-host.md`.
+- **16 new tests** in `tests/test_adapter_agents_md.py`: pure-unit coverage of `_replace_section` (idempotent, append-when-missing, replace-in-place, preserve-prefix-suffix, malformed-marker tolerance), integration coverage with a real git repo (writes/skips by event, preserves user content, filename override including subdirectory paths, write-failure swallowed), and dispatch coverage (all 3 PRESENCE_HOST aliases routing correctly).
+
+### Changed
+
+- **`README.md`**: recent-changes callout names v0.4.2 as the cross-tool release; v0.4.1 (MCP) is now positioned as the live-pull complement to v0.4.2's push-to-file approach.
+- **`README.md` "By the numbers"**: surface area row updated to mention the multi-host adapter (alongside the existing MCP server).
+
+### What's NOT in v0.4.2
+
+- **Per-tool adapters** (separate Cursor, Gemini, Codex classes): unnecessary because AGENTS.md serves all of them. The `PRESENCE_AGENTS_MD_FILENAME` override covers the rare case where a user prefers a specific tool's filename over the cross-tool standard.
+- **`clawbot` adapter**: not shipping. The tool is not publicly documented in any source verified at v0.4.2 time. File an issue with a pointer to the spec; we'll add a v0.4.3 patch.
+- **ACP (Agent Client Protocol from Zed)**: distinct from AGENTS.md (chat-session control vs. give-me-context). Tracked as v0.4.3 / v0.5.0.
+
+### Closes
+
+- Roadmap issue #8 (Multi-AI-tool adapter architecture). Originally planned as v1.0 work; brought forward to v0.4.x and shipped in 3 minor releases (v0.4.0 seam, v0.4.1 MCP, v0.4.2 AGENTS.md). The remaining open question (Zed ACP) is its own scope and stays open under a separate roadmap entry.
+
+### Quality gates
+
+- 256 tests passing on Python 3.12 / 3.13 / 3.14 (was 240 in v0.4.1; +16 from `test_adapter_agents_md.py`).
+- ruff clean. shellcheck clean. MANIFEST verifies. ASCII-only. No em-dashes.
+- Backward compat: every v0.3.x / v0.4.x state file remains readable. The `claude` host (default) is byte-identical to v0.4.1 behavior. AGENTS.md adapter only writes when `PRESENCE_HOST=agents-md` is explicitly set; default users see no change to their working tree.
+
 ## v0.4.1
 
 Ships the Model Context Protocol (MCP) server (`lib/mcp_server.py`) deferred from v0.4.0. Any MCP-aware client (Claude Desktop, Cursor, Continue, custom agents) can now read presence's living project model and outcome telemetry over JSON-RPC stdio without going through Claude Code-specific hook plumbing.

--- a/MANIFEST.lock
+++ b/MANIFEST.lock
@@ -2,7 +2,7 @@
   "_format": 1,
   "files": {
     ".claude-plugin/marketplace.json": "066ae0d198f750ebfb7b1df4d1b2dffc3db01030d8c5d5865be0064c007c79ff",
-    ".claude-plugin/plugin.json": "7f33eef966353258c647ec7e8da9fbbcbe4aad30159b33e5680f5bf6e03c7170",
+    ".claude-plugin/plugin.json": "2fbf55b39d0c6b13ae626b48496e9d4706933d13c9f6a4a7b2a6dda679551ec8",
     "agents/model-curator.md": "1b8381997ea4c29944e1388b7467ca38787c893801e8bfd79460c103d0e169d5",
     "commands/presence-bugreport.md": "dfa35b61dfcf30f0f268fb0c8fed6dbd92f7da058fca34f07b9beab8a52ddf79",
     "commands/presence-curate.md": "9295204486515a9dfd1a66ee77b64b067fdcb04ca436f182106659b33d504986",
@@ -19,7 +19,7 @@
     "hooks/scripts/session-start.sh": "8d1c7ae9ae0884fb88bc9e18f949dc9d5bd1c3ce1aff40da14088128917b09fb",
     "hooks/scripts/stop.sh": "54ead2f0f29aefcf9120f44f99f9c7f5357fbbacc9330d28e942200947595267",
     "hooks/scripts/user-prompt-submit.sh": "006cc582419f061934dc94842de6240722b48ac23578c1b0c84ae1ceaad6df60",
-    "lib/__init__.py": "ec1eb997317666643fd63c9cfc806926af57f5beb4e9dd6145de68c9893415cb",
+    "lib/__init__.py": "5e171d07bfd0cb897c746e0b690913003af75d6b386ddea4bb90ad2830fd846e",
     "lib/_common.py": "207cbcc6d0327aafd8cbea6f666564e2d2d937c2c54473fe03803b7e09300e95",
     "lib/audit.py": "d71dada0ad335a0495e17afd04bbcb2f7c6e81fd163d8d3036ba83b5dbc1fa2a",
     "lib/bugreport.py": "6d1f518382e33e032dedff37a4007c7dcc1d7a196100431d86f1d48c36f049fd",

--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ The `--build-ext` column reflects optional native acceleration via the Rust daem
 All measurements: macOS arm64, Python 3.14.4. Reproduce locally with `python3 bench/<name>.py --runs N`. See [`bench/README.md`](bench/README.md) for the full convention.
 
 > **Recent changes**: see [`CHANGELOG.md`](CHANGELOG.md) for the full per-version diff.
-> v0.4.1 ships the MCP server: any MCP-aware client (Claude Desktop, Cursor, Continue, custom agents) can read presence's living model + outcome telemetry over JSON-RPC stdio. See [`docs/mcp.md`](docs/mcp.md).
-> v0.4.0 shipped the Rust daemon client + warm Python daemon + adapter seam. Optional via `--build-ext` / `--download-ext`. Cuts hot-path latency from 82 ms to 8.9 ms (-89%). Multi-host adapters (Cursor, Gemini, Codex, claude-code, clawbot, generic) land in v0.4.2.
+> v0.4.2 ships the cross-tool AGENTS.md adapter. Set `PRESENCE_HOST=agents-md` and presence refreshes `<repo>/AGENTS.md` on every Claude Code SessionStart, picked up automatically by Codex, Cursor, Gemini CLI, Windsurf, GitHub Copilot, and others reading the open AGENTS.md standard. See [`docs/multi-host.md`](docs/multi-host.md).
+> v0.4.1 shipped the MCP server: any MCP-aware client (Claude Desktop, Cursor, Continue, custom agents) can read presence's living model + outcome telemetry over JSON-RPC stdio. See [`docs/mcp.md`](docs/mcp.md).
+> v0.4.0 shipped the Rust daemon client + warm Python daemon + adapter seam. Optional via `--build-ext` / `--download-ext`. Cuts hot-path latency from 82 ms to 8.9 ms (-89%).
 > v0.3.x cut cold-hook latency by ~27% and fixed a latent v0.2 bug where Zero-Trust users had their event digest silently emptied.
 > v0.2.0 shipped the Zero-Trust preset: AES-GCM at rest, tamper-evident audit log, fail-closed SessionStart integrity. See [`docs/zerotrust.md`](docs/zerotrust.md).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,7 @@ Quick map of what lives where. If you're a new user start with the README; this 
 - **[glossary.md](glossary.md)** - definitions for the terms presence uses (living model, calibrated confidence, integrity manifest, etc.). Read this if a term you saw in the README isn't obvious.
 - **[recipes.md](recipes.md)** - common preset customizations as copy-paste snippets ("warn-only commit gate", "longer transcript scan", "back up my state", etc.).
 - **[mcp.md](mcp.md)** - Model Context Protocol integration. Exposes presence's living model + telemetry as MCP resources for Claude Desktop, Cursor, Continue, and any other MCP-aware client.
+- **[multi-host.md](multi-host.md)** - cross-tool AGENTS.md adapter (v0.4.2+). One env var lets Codex, Cursor, Gemini CLI, Windsurf, GitHub Copilot, and others read presence's accumulated context.
 - **[roadmap.md](roadmap.md)** - what we've decided to defer and why (multi-tool, native Windows, release automation, snapshots, schema validation, side-by-side installs). Each item has a tracking issue with the same title.
 
 ## See also

--- a/docs/multi-host.md
+++ b/docs/multi-host.md
@@ -1,0 +1,122 @@
+# Multi-host: AGENTS.md adapter (v0.4.2+)
+
+presence runs as a Claude Code plugin. v0.4.2 lets it project its accumulated knowledge into other AI coding tools without porting the whole hook system to each one.
+
+The mechanism: when Claude Code's `SessionStart` hook fires, presence refreshes a delimited section of `<repo_root>/AGENTS.md`. The next time the user opens **any AGENTS.md-aware tool** in the same repo (Codex, Cursor, Gemini CLI, Windsurf, GitHub Copilot, etc.), that tool reads the refreshed AGENTS.md as part of its first-turn context.
+
+## Hosts that read AGENTS.md (verified 2026-04)
+
+Per the [OpenAI Codex AGENTS.md guide](https://developers.openai.com/codex/guides/agents-md) and [agents.md](https://agents.md/), AGENTS.md is now an **open standard** under the Agentic AI Foundation (Linux Foundation directed fund). Tools that read it:
+
+- **OpenAI Codex CLI** (the format's origin)
+- **Cursor** (legacy `.cursorrules` is being replaced; `.cursor/rules/*.mdc` is the new way; AGENTS.md works as a fallback)
+- **Gemini CLI** (also reads its preferred `GEMINI.md`; AGENTS.md works as a fallback per Google's docs)
+- **Windsurf** (Cascade)
+- **GitHub Copilot** (in IDEs that support it)
+- **Many community tools** following the open standard
+
+This is why v0.4.2 ships **one** adapter rather than five.
+
+## Quickstart
+
+In your shell, when running a Claude Code session in a repo:
+
+```bash
+PRESENCE_HOST=agents-md
+```
+
+Set this env var before opening Claude Code. From then on, every Claude Code session refreshes `<repo>/AGENTS.md` with presence's living model + telemetry digest. When you later open Codex / Cursor / Gemini / Windsurf in the same repo, they pick it up automatically.
+
+To make it permanent in your shell:
+
+```bash
+echo 'export PRESENCE_HOST=agents-md' >> ~/.zshrc   # or ~/.bashrc
+```
+
+## Filename override
+
+Some tools prefer their own filename (`GEMINI.md` for Gemini CLI's primary file, `.cursor/rules/presence.mdc` for Cursor's new rules format). Override:
+
+```bash
+PRESENCE_AGENTS_MD_FILENAME=GEMINI.md
+# or
+PRESENCE_AGENTS_MD_FILENAME=.cursor/rules/presence.mdc
+```
+
+Subdirectory paths work; the adapter creates the parent directories. Defaults to `AGENTS.md` when unset.
+
+## File contract: how presence behaves inside YOUR file
+
+presence is a guest in `AGENTS.md`. It writes only to a delimited section:
+
+```markdown
+<!-- presence:start -->
+<!-- This block is managed by presence (https://github.com/sara-star-quant/presence). -->
+<!-- It refreshes at the start of each Claude Code session. Edit outside the markers. -->
+
+<presence_context>
+<project_model>
+... (presence's living model)
+</project_model>
+<telemetry_digest>
+... (recent commits, reverts, verification claims)
+</telemetry_digest>
+</presence_context>
+
+<!-- presence:end -->
+```
+
+Everything outside the markers is **left exactly as you wrote it**. The adapter is idempotent: refreshing twice with the same content produces the same file. Refreshing with new content replaces only the section between the markers.
+
+If `AGENTS.md` does not exist, the adapter creates it containing only the presence section. If you'd rather not have presence write the file at all, just don't set `PRESENCE_HOST=agents-md`.
+
+## When does the refresh happen?
+
+Only on Claude Code's `SessionStart` event. Other hooks (`UserPromptSubmit`, `PostToolUse`, `Stop`) are ignored by this adapter to avoid writing-on-every-keystroke noise. The freshest model + telemetry digest is assembled at SessionStart anyway.
+
+If you want manual control, run `/presence-status` (no auto-refresh) or `/presence-doctor` (diagnostic only). Neither writes to AGENTS.md.
+
+## Should I commit AGENTS.md?
+
+That's a workflow choice, not a presence opinion:
+
+- **Commit it**: your team gets the same AI context. Each team member's presence will refresh the section on their own machine, so the section's *content* will diff between commits (presence-managed). User-authored content stays stable across machines.
+- **`.gitignore` it**: AGENTS.md becomes per-developer. Useful when each contributor's presence-tracked telemetry differs and you don't want diff noise.
+- **Hybrid**: commit a hand-authored AGENTS.md with your team's conventions outside the markers; `.gitignore` is wrong here, but consider using `git update-index --skip-worktree AGENTS.md` to track the user-content version while ignoring the presence-managed section's churn.
+
+The tradeoffs are the same as for any auto-generated file in version control. presence has no preference.
+
+## Recognized PRESENCE_HOST values
+
+| Value | Adapter | What it does |
+|---|---|---|
+| `claude` (default) | `ClaudeAdapter` | Emits Claude Code's `hookSpecificOutput` JSON. The hook protocol presence has used since v0.1. |
+| `agents-md` (and `agents_md`, `agents`) | `AgentsMdAdapter` | Refresh `<repo>/AGENTS.md` (or `$PRESENCE_AGENTS_MD_FILENAME`) on SessionStart. v0.4.2+. |
+| `generic` | `GenericAdapter` | Plain-text stdout. Useful for debugging presence outside Claude Code. |
+| anything else | falls through to `ClaudeAdapter` | Safe default; presence's "never break a hook" stance. |
+
+## What's NOT shipping in v0.4.2
+
+- **Per-tool adapters** (Cursor / Gemini / Codex separate classes): unnecessary because AGENTS.md serves all of them. The single override `PRESENCE_AGENTS_MD_FILENAME` covers users who want the tool-specific filename.
+- **Live MCP integration**: that's v0.4.1 (`docs/mcp.md`). MCP-aware tools (Claude Desktop, Cursor, Continue) can use the MCP server for live reads instead of, or in addition to, the AGENTS.md refresh.
+- **ACP** (Agent Client Protocol from Zed): chat-session control, distinct from AGENTS.md's "give me context." Tracked as v0.4.3 / v0.5.0.
+- **`clawbot` adapter**: this tool is not publicly documented in any source verified at the time of v0.4.2; if support is needed, file an issue with a pointer to the spec and we'll add a v0.4.3 patch.
+
+## Compared to MCP (v0.4.1)
+
+| | MCP server (v0.4.1) | AGENTS.md adapter (v0.4.2) |
+|---|---|---|
+| **Direction** | Client pulls from presence | presence pushes to file |
+| **Freshness** | Live (read on each MCP request) | Refreshed on Claude Code SessionStart |
+| **Tool support** | Claude Desktop, Cursor, Continue, others with MCP support | Codex, Cursor, Gemini, Windsurf, Copilot, others reading AGENTS.md |
+| **Setup** | Per-client MCP config (one entry per tool) | One env var (`PRESENCE_HOST=agents-md`) |
+| **Disk writes** | None | One file per repo, only on SessionStart |
+| **Use both?** | Yes, they're independent and serve different tools |
+
+Most users will pick one or the other. Power users with multiple AI tools open simultaneously can run both.
+
+## See also
+
+- [`mcp.md`](mcp.md) - MCP server (v0.4.1)
+- [`recipes.md`](recipes.md) - common preset customizations
+- [`architecture.md`](architecture.md) - the adapter seam in context

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -1,2 +1,2 @@
 """presence: continuous-collaboration layer for Claude Code."""
-__version__ = "0.4.1"
+__version__ = "0.4.2"

--- a/lib/adapters/__init__.py
+++ b/lib/adapters/__init__.py
@@ -1,30 +1,47 @@
 """Host-AI-tool adapter seam.
 
-v0.4.0 ships only the Claude Code adapter (the project's primary host).
-Future versions add adapters for other AI coding tools:
-  v0.4.1 - MCP server entry (any MCP-aware client)
-  v0.4.2 - Cursor, Gemini, Codex, claude-code (Anthropic), clawbot,
-           plus a generic-fallback adapter for any other host.
-
 Selected by the ``PRESENCE_HOST`` environment variable; defaults to
-``claude``. The full list of recognized values lives in this file's
-get_adapter() so the supported set is discoverable by ``grep``.
+``claude``. Recognized values:
+
+  ``claude``     -> ClaudeAdapter: emits Claude Code's hookSpecificOutput
+                    JSON shape. Default; matches v0.3.x and v0.4.0 behavior.
+  ``agents-md``  -> AgentsMdAdapter: refresh a delimited section of
+                    ``<repo_root>/AGENTS.md`` (or ``$PRESENCE_AGENTS_MD_FILENAME``)
+                    on SessionStart. AGENTS.md is the cross-tool open
+                    standard read by Codex, Cursor, Gemini CLI, Windsurf,
+                    GitHub Copilot, and others. v0.4.2+.
+  ``generic``    -> GenericAdapter: plain-text stdout. Useful for debugging
+                    presence outside Claude Code.
+
+Unknown hosts fall through to ClaudeAdapter (the safest default for hooks
+running inside Claude Code).
 """
 import os
 
+from .agents_md import AgentsMdAdapter
 from .base import Adapter
 from .claude import ClaudeAdapter
+from .generic import GenericAdapter
+
+_REGISTRY: dict[str, type[Adapter]] = {
+    "claude": ClaudeAdapter,
+    "agents-md": AgentsMdAdapter,
+    "agents_md": AgentsMdAdapter,   # tolerate underscore form
+    "agents":    AgentsMdAdapter,   # short alias
+    "generic":   GenericAdapter,
+}
 
 
 def get_adapter() -> Adapter:
-    # ``host`` is normalized to lowercase. Unknown hosts fall through to
-    # ClaudeAdapter (default) rather than raising; presence's "never break a
-    # hook" stance applies even to misconfiguration.
-    host = os.environ.get("PRESENCE_HOST", "claude").lower()
-    # The recognized list will grow in v0.4.2; for now only "claude" is wired.
-    if host == "claude":
-        return ClaudeAdapter()
-    return ClaudeAdapter()
+    host = os.environ.get("PRESENCE_HOST", "claude").lower().strip()
+    cls = _REGISTRY.get(host, ClaudeAdapter)
+    return cls()
 
 
-__all__ = ["Adapter", "ClaudeAdapter", "get_adapter"]
+__all__ = [
+    "Adapter",
+    "AgentsMdAdapter",
+    "ClaudeAdapter",
+    "GenericAdapter",
+    "get_adapter",
+]

--- a/lib/adapters/agents_md.py
+++ b/lib/adapters/agents_md.py
@@ -1,0 +1,116 @@
+"""AgentsMdAdapter: refresh a delimited section of AGENTS.md at SessionStart.
+
+AGENTS.md became an open standard in 2026 (Agentic AI Foundation, Linux
+Foundation directed fund) and is read by Codex, Cursor, Gemini CLI,
+Windsurf, GitHub Copilot, and dozens of other AI coding tools. presence
+runs as a Claude Code plugin; this adapter lets the same machine's other
+AI tools see presence's accumulated project knowledge by refreshing the
+project's AGENTS.md every time a Claude Code SessionStart hook fires.
+
+Filename override: ``PRESENCE_AGENTS_MD_FILENAME`` env var. Defaults to
+``AGENTS.md``. Useful values:
+  - ``AGENTS.md`` (default; works for all AGENTS.md-aware tools)
+  - ``GEMINI.md`` (Gemini CLI's preferred name; also works as a fallback)
+  - ``.cursor/rules/presence.mdc`` (Cursor's modular rules format)
+
+Section delimiters: ``<!-- presence:start -->`` ... ``<!-- presence:end -->``.
+Presence-managed content is replaced inside these markers; everything else
+in the file is left alone. Idempotent.
+
+Event scope: this adapter ONLY acts on ``SessionStart`` events. Hooks that
+fire continuously (UserPromptSubmit, PostToolUse, etc.) would write to disk
+on every fire, which is unnecessary noise; SessionStart is when the model
++ telemetry digest is freshest.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from .base import Adapter
+
+DEFAULT_FILENAME = "AGENTS.md"
+START_MARKER = "<!-- presence:start -->"
+END_MARKER = "<!-- presence:end -->"
+
+
+def _project_root() -> Path:
+    """Return the repo root (git toplevel) or the current working directory.
+
+    Imported from _common to reuse the existing git-aware resolution; that
+    helper already handles non-git directories gracefully.
+    """
+    from _common import repo_root
+    return repo_root()
+
+
+def _target_path() -> Path:
+    """Resolve the AGENTS.md target file. Honors PRESENCE_AGENTS_MD_FILENAME."""
+    filename = os.environ.get("PRESENCE_AGENTS_MD_FILENAME", DEFAULT_FILENAME)
+    return _project_root() / filename
+
+
+def _build_section(text: str) -> str:
+    """Wrap ``text`` in the presence-managed section markers."""
+    return (
+        f"{START_MARKER}\n"
+        f"<!-- This block is managed by presence (https://github.com/sara-star-quant/presence). -->\n"
+        f"<!-- It refreshes at the start of each Claude Code session. Edit outside the markers. -->\n"
+        f"\n"
+        f"{text.strip()}\n"
+        f"\n"
+        f"{END_MARKER}\n"
+    )
+
+
+def _replace_section(existing: str, new_section: str) -> str:
+    """Replace the existing presence-managed section, or append if missing.
+
+    Idempotent: calling twice with the same new_section produces the same
+    result. User-authored content outside the markers is preserved exactly.
+    """
+    start = existing.find(START_MARKER)
+    end = existing.find(END_MARKER)
+    if start == -1 or end == -1 or end < start:
+        # No existing section; append (with a blank line if the file is non-empty).
+        sep = "\n" if existing and not existing.endswith("\n") else ""
+        if existing.strip():
+            return existing + sep + "\n" + new_section
+        return new_section
+    # Replace the section in place. end + len(END_MARKER) covers the closing tag;
+    # also consume one trailing newline if present for clean idempotence.
+    end_pos = end + len(END_MARKER)
+    if end_pos < len(existing) and existing[end_pos] == "\n":
+        end_pos += 1
+    return existing[:start] + new_section + existing[end_pos:]
+
+
+class AgentsMdAdapter(Adapter):
+    """Refresh AGENTS.md (or override) on SessionStart; noop on other events.
+
+    The text content presence assembles for SessionStart already includes
+    the living model, telemetry digest, and recent events wrapped in XML
+    tags. We pass that text through verbatim into the AGENTS.md section so
+    AGENTS.md-aware tools see the same context Claude Code would.
+    """
+
+    def emit_context(self, event_name: str, text: str) -> None:
+        if event_name != "SessionStart" or not text:
+            return
+        target = _target_path()
+        try:
+            existing = target.read_text(encoding="utf-8") if target.exists() else ""
+        except OSError:
+            existing = ""
+        new_section = _build_section(text)
+        updated = _replace_section(existing, new_section)
+        if updated == existing:
+            return
+        try:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(updated, encoding="utf-8")
+        except OSError:
+            # Never break a hook on a write failure; the user's repo may be
+            # read-only, on a network mount, etc. presence's stance: hooks
+            # are best-effort observers, never required to succeed.
+            pass

--- a/lib/adapters/generic.py
+++ b/lib/adapters/generic.py
@@ -1,0 +1,19 @@
+"""GenericAdapter: plain-text stdout for unknown / debug hosts.
+
+Useful when running presence outside of Claude Code (e.g., manually firing
+a hook for testing) or when no specific host adapter applies. Mimics the
+shape of a Claude Code hook block but in human-readable text.
+"""
+from __future__ import annotations
+
+import sys
+
+from .base import Adapter
+
+
+class GenericAdapter(Adapter):
+    def emit_context(self, event_name: str, text: str) -> None:
+        if not text:
+            return
+        sys.stdout.write(f"\n[presence: {event_name}]\n{text}\n")
+        sys.stdout.flush()

--- a/tests/test_adapter_agents_md.py
+++ b/tests/test_adapter_agents_md.py
@@ -1,0 +1,226 @@
+"""Tests for the AgentsMdAdapter (v0.4.2).
+
+Cross-tool: AGENTS.md is the open standard read by Codex, Cursor, Gemini
+CLI, Windsurf, GitHub Copilot. The adapter refreshes a delimited section
+on SessionStart so any AGENTS.md-aware tool the user opens after presence
+runs sees fresh project context.
+
+Critical guarantees:
+  - Idempotent: writing twice produces the same file content.
+  - Preserves user-authored content outside the markers.
+  - Acts only on SessionStart (not on every UserPromptSubmit fire).
+  - Filename overridable via PRESENCE_AGENTS_MD_FILENAME.
+  - Never raises (failed write -> silent; never breaks a hook).
+"""
+from __future__ import annotations
+
+import pytest
+from adapters.agents_md import (
+    END_MARKER,
+    START_MARKER,
+    AgentsMdAdapter,
+    _build_section,
+    _replace_section,
+)
+
+# ---------------------------------------------------------------------------
+# _replace_section: pure unit tests, no filesystem.
+# ---------------------------------------------------------------------------
+
+def test_replace_section_appends_when_missing():
+    existing = "# my project\n\nSome notes.\n"
+    new = _build_section("test payload")
+    out = _replace_section(existing, new)
+    assert out.startswith(existing)
+    assert START_MARKER in out
+    assert "test payload" in out
+
+
+def test_replace_section_replaces_in_place():
+    existing = (
+        "# my project\n\n"
+        f"{START_MARKER}\nold content\n{END_MARKER}\n"
+        "Below the section.\n"
+    )
+    new = _build_section("fresh content")
+    out = _replace_section(existing, new)
+    assert "old content" not in out
+    assert "fresh content" in out
+    # Below the section is preserved exactly.
+    assert "Below the section." in out
+    # User-authored prefix preserved.
+    assert out.startswith("# my project\n\n")
+
+
+def test_replace_section_idempotent():
+    """Two writes with the same content produce identical output."""
+    existing = "# my project\n\n"
+    new = _build_section("payload v1")
+    once = _replace_section(existing, new)
+    twice = _replace_section(once, new)
+    assert once == twice
+
+
+def test_replace_section_handles_empty_existing():
+    new = _build_section("first time")
+    out = _replace_section("", new)
+    assert out == new
+
+
+def test_replace_section_handles_malformed_markers():
+    """Marker only at start (no end) -> treated as missing; appended cleanly."""
+    existing = f"random text {START_MARKER} but no end marker\n"
+    new = _build_section("payload")
+    out = _replace_section(existing, new)
+    # Old half-marker preserved (we don't try to repair it); new full section appended.
+    assert START_MARKER in out
+    assert END_MARKER in out
+
+
+# ---------------------------------------------------------------------------
+# AgentsMdAdapter: integration with a real working tree.
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def repo_with_state(tmp_path, monkeypatch):
+    """A tmp dir set up as cwd + git repo so repo_root() resolves cleanly."""
+    import subprocess
+    repo = tmp_path / "fake-repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "t@t"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "--allow-empty", "-m", "init", "-q"], cwd=repo, check=True)
+    monkeypatch.chdir(repo)
+    return repo
+
+
+def test_session_start_writes_agents_md(repo_with_state):
+    adapter = AgentsMdAdapter()
+    adapter.emit_context("SessionStart", "<presence_context>hello</presence_context>")
+    target = repo_with_state / "AGENTS.md"
+    assert target.exists()
+    content = target.read_text(encoding="utf-8")
+    assert START_MARKER in content
+    assert END_MARKER in content
+    assert "<presence_context>hello</presence_context>" in content
+
+
+def test_non_session_start_event_does_nothing(repo_with_state):
+    adapter = AgentsMdAdapter()
+    adapter.emit_context("UserPromptSubmit", "ignored payload")
+    assert not (repo_with_state / "AGENTS.md").exists()
+
+
+def test_empty_text_does_not_create_file(repo_with_state):
+    adapter = AgentsMdAdapter()
+    adapter.emit_context("SessionStart", "")
+    assert not (repo_with_state / "AGENTS.md").exists()
+
+
+def test_existing_agents_md_user_content_preserved(repo_with_state):
+    """User-authored AGENTS.md content outside the presence section must
+    survive. This is the critical contract: presence is a guest in the
+    user's file."""
+    target = repo_with_state / "AGENTS.md"
+    target.write_text(
+        "# Project Conventions\n\n"
+        "Use 2-space indentation.\n\n"
+        "## Style\n\n"
+        "ASCII-only.\n",
+        encoding="utf-8",
+    )
+    AgentsMdAdapter().emit_context("SessionStart", "fresh presence content")
+    after = target.read_text(encoding="utf-8")
+    # User content untouched.
+    assert "Use 2-space indentation." in after
+    assert "ASCII-only." in after
+    # presence section appended.
+    assert "fresh presence content" in after
+    assert START_MARKER in after
+
+
+def test_filename_override_via_env(repo_with_state, monkeypatch):
+    monkeypatch.setenv("PRESENCE_AGENTS_MD_FILENAME", "GEMINI.md")
+    AgentsMdAdapter().emit_context("SessionStart", "hi")
+    assert (repo_with_state / "GEMINI.md").exists()
+    # Default file NOT created when override is set.
+    assert not (repo_with_state / "AGENTS.md").exists()
+
+
+def test_filename_override_supports_subdirectory(repo_with_state, monkeypatch):
+    """Cursor's new-format rules live under .cursor/rules/. The override
+    should be allowed to specify a path with a directory; the adapter
+    creates parent dirs."""
+    monkeypatch.setenv("PRESENCE_AGENTS_MD_FILENAME", ".cursor/rules/presence.mdc")
+    AgentsMdAdapter().emit_context("SessionStart", "rules payload")
+    target = repo_with_state / ".cursor" / "rules" / "presence.mdc"
+    assert target.exists()
+    assert "rules payload" in target.read_text(encoding="utf-8")
+
+
+def test_idempotent_writes_produce_same_file(repo_with_state):
+    adapter = AgentsMdAdapter()
+    payload = "<presence_context>same text</presence_context>"
+    adapter.emit_context("SessionStart", payload)
+    first = (repo_with_state / "AGENTS.md").read_text()
+    adapter.emit_context("SessionStart", payload)
+    second = (repo_with_state / "AGENTS.md").read_text()
+    assert first == second
+
+
+def test_refresh_replaces_old_payload_only(repo_with_state):
+    """A second SessionStart with new content replaces the OLD presence
+    section; user content stays intact."""
+    target = repo_with_state / "AGENTS.md"
+    target.write_text("# user header\n\nstable content\n", encoding="utf-8")
+    AgentsMdAdapter().emit_context("SessionStart", "round 1")
+    AgentsMdAdapter().emit_context("SessionStart", "round 2")
+    final = target.read_text(encoding="utf-8")
+    assert "stable content" in final
+    assert "round 2" in final
+    assert "round 1" not in final
+
+
+def test_write_failure_does_not_raise(repo_with_state, monkeypatch):
+    """If the target file can't be written (read-only fs, permission issue),
+    the adapter must swallow the error - hooks must never break Claude Code."""
+    target = repo_with_state / "AGENTS.md"
+    target.write_text("existing\n", encoding="utf-8")
+    # Make the directory read-only.
+    import stat
+    repo_with_state.chmod(stat.S_IRUSR | stat.S_IXUSR)
+    try:
+        # Must not raise.
+        AgentsMdAdapter().emit_context("SessionStart", "payload")
+    finally:
+        # Restore so cleanup works.
+        repo_with_state.chmod(0o700)
+
+
+# ---------------------------------------------------------------------------
+# Adapter dispatch via PRESENCE_HOST.
+# ---------------------------------------------------------------------------
+
+def test_presence_host_agents_md_routes_to_agents_md_adapter(monkeypatch):
+    monkeypatch.setenv("PRESENCE_HOST", "agents-md")
+    from adapters import get_adapter
+    assert isinstance(get_adapter(), AgentsMdAdapter)
+
+
+def test_presence_host_underscore_alias_routes_to_agents_md_adapter(monkeypatch):
+    monkeypatch.setenv("PRESENCE_HOST", "agents_md")
+    from adapters import get_adapter
+    assert isinstance(get_adapter(), AgentsMdAdapter)
+
+
+def test_presence_host_short_alias_routes_to_agents_md_adapter(monkeypatch):
+    monkeypatch.setenv("PRESENCE_HOST", "agents")
+    from adapters import get_adapter
+    assert isinstance(get_adapter(), AgentsMdAdapter)
+
+
+def test_presence_host_generic_routes_to_generic_adapter(monkeypatch):
+    monkeypatch.setenv("PRESENCE_HOST", "generic")
+    from adapters import GenericAdapter, get_adapter
+    assert isinstance(get_adapter(), GenericAdapter)


### PR DESCRIPTION
## Summary

Closes roadmap issue #8 (Multi-AI-tool adapter architecture).

The original v0.4.2 plan called for per-tool adapters (Cursor, Gemini, Codex, claude-code, clawbot, generic). Verification against current docs (April 2026) revealed that **`AGENTS.md` is now an open standard under the Agentic AI Foundation (Linux Foundation directed fund)**, read by Codex, Cursor, Gemini CLI, Windsurf, GitHub Copilot, and dozens of other tools.

That collapses the design to **one universal adapter** that refreshes the project's `AGENTS.md` at Claude Code's `SessionStart` event, with a filename override for users who prefer a tool-specific name (`GEMINI.md`, `.cursor/rules/presence.mdc`, etc.). One env var (`PRESENCE_HOST=agents-md`) turns it on; everything else stays unchanged.

## What changed

### Added

- **`lib/adapters/agents_md.py`**: `AgentsMdAdapter`. Refreshes a delimited section (`<!-- presence:start --> ... <!-- presence:end -->`) of `<repo_root>/AGENTS.md` on `SessionStart` events. Idempotent; preserves user-authored content outside the markers; never raises on write failure (presence's "never break a hook" stance applies). `PRESENCE_AGENTS_MD_FILENAME` env var overrides the filename. Subdirectory paths in the override work; parent dirs are created.
- **`lib/adapters/generic.py`**: `GenericAdapter`. Plain-text stdout for unknown / debug hosts.
- **`lib/adapters/__init__.py`**: `PRESENCE_HOST` dispatch -> `claude` (default), `agents-md` / `agents_md` / `agents` aliases, `generic`. Unknown values fall through to `ClaudeAdapter`.
- **`docs/multi-host.md`** (new): full guide. Hosts that read AGENTS.md (verified April 2026), file contract, idempotent semantics, filename override with subdirectory support, should-I-commit tradeoff, comparison with v0.4.1 MCP server.
- **`docs/index.md`**: links to `multi-host.md`.
- **16 new tests** in `tests/test_adapter_agents_md.py`: pure-unit `_replace_section` cases (idempotent, append-when-missing, replace-in-place, preserve-prefix-suffix, malformed-marker tolerance), integration with a real git repo (writes/skips by event, preserves user content, filename override including subdirs, write-failure swallowed), and dispatch coverage (3 `PRESENCE_HOST` aliases routing).

### Changed

- **`README.md`**: recent-changes callout names v0.4.2 as the cross-tool release; v0.4.1 (MCP) is repositioned as live-pull complement to v0.4.2's push-to-file approach.

## What's NOT in v0.4.2

- **Per-tool adapter classes** (Cursor / Gemini / Codex separate): unnecessary because AGENTS.md serves all of them. The `PRESENCE_AGENTS_MD_FILENAME` override covers per-tool preferences.
- **`clawbot` adapter**: not shipping. Tool not publicly documented in any verified source as of April 2026; will add as v0.4.3 patch with a spec pointer.
- **ACP (Agent Client Protocol from Zed)**: distinct from AGENTS.md (chat-session control vs. give-me-context). Tracked as v0.4.3 / v0.5.0.

## Backward compatibility

Every v0.3.x / v0.4.x state file remains readable. The `claude` host (default) is byte-identical to v0.4.1 behavior. AGENTS.md adapter only writes when `PRESENCE_HOST=agents-md` is explicitly set; default users see no change to their working tree.

## Test plan

- [x] `python -m pytest -q` -> 256 passed, 1 skipped (was 240 in v0.4.1; +16 from `test_adapter_agents_md.py`)
- [x] `python -m ruff check lib tests bench` -> clean
- [x] `shellcheck install.sh hooks/scripts/*.sh` -> clean
- [x] `PYTHONPATH=lib python3 lib/integrity.py --verify` -> integrity OK
- [x] Manual: with `PRESENCE_HOST=agents-md`, fire SessionStart -> AGENTS.md created with section markers
- [x] Manual: fire SessionStart twice with same payload -> file content identical (idempotent)
- [x] Manual: with user content outside markers, fire SessionStart -> user content preserved
- [x] CI green on Python 3.12 / 3.13 / 3.14 across Linux + macOS

## Follow-ups

- After merge: tag `v0.4.2`. release.yml will publish (matrix may still hit Intel runner queue; macOS arm64 + Linux x86_64 builds usually complete within a few minutes).
- Linux Rust build still needs a fix (libgit2 system deps; `apt-get install pkg-config libssh2-dev libssl-dev` step in release.yml). Tracked as a follow-up patch.
- ACP / Zed adapter: separate PR, v0.4.3 / v0.5.0.