### PR TITLE
ci: fix Linux Rust build (libgit2 deps) + bump artifact actions to v6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,18 @@ jobs:
         if: steps.check_ext.outputs.have_ext == 'true'
         with:
           targets: ${{ matrix.target }}
+      - name: Install system libraries (Linux only)
+        # The git2 crate links against libgit2 which needs pkg-config +
+        # libssh2 + libssl headers. Bare ubuntu-latest runners don't have
+        # them. macOS runners get equivalents via Apple's frameworks.
+        if: steps.check_ext.outputs.have_ext == 'true' && runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            pkg-config \
+            libssh2-1-dev \
+            libssl-dev \
+            zlib1g-dev
       - name: Build presence-client
         if: steps.check_ext.outputs.have_ext == 'true'
         env:
@@ -71,8 +83,10 @@ jobs:
           chmod +x "/tmp/release-assets/$ARTIFACT_NAME"
           ls -la /tmp/release-assets/
       - name: Upload artifact
+        # v6 runs on Node 24; v4 was deprecated by GitHub Actions (Node 20
+        # removal scheduled for September 2026, default flip June 2026).
         if: steps.check_ext.outputs.have_ext == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.artifact }}
           path: /tmp/release-assets/${{ matrix.artifact }}
@@ -142,7 +156,8 @@ jobs:
           fi
 
       - name: Download Rust build artifacts (best-effort)
-        uses: actions/download-artifact@v4
+        # v6 runs on Node 24; matches the upload-artifact bump above.
+        uses: actions/download-artifact@v6
         with:
           path: /tmp/release-assets
         continue-on-error: true   # release notes still publish even if Rust builds failed


### PR DESCRIPTION
Two release.yml hygiene fixes observed in v0.4.0 / v0.4.1 / v0.4.2 release runs.

## Fix 1: Linux x86_64 build

`cargo build` for the Linux target failed with exit 101 because the `git2` crate links against libgit2, which needs system libraries that bare ubuntu-latest runners don't have. macOS runners get equivalents via Apple's frameworks. Added a Linux-only step:

```yaml
- name: Install system libraries (Linux only)
  if: steps.check_ext.outputs.have_ext == 'true' && runner.os == 'Linux'
  run: |
    sudo apt-get update
    sudo apt-get install -y --no-install-recommends \
      pkg-config libssh2-1-dev libssl-dev zlib1g-dev
```

## Fix 2: Node 24 / actions versions

`actions/upload-artifact@v4` and `actions/download-artifact@v4` are deprecated; they run on Node 20 which GitHub Actions will force-replace with Node 24 by default starting **June 2026** and remove entirely **September 2026**. Bumped both to v6 (Node 24 native).

## Test plan

- [x] `python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/release.yml'))\"` -> YAML valid
- [ ] CI: the next v* tag push (or a manual `workflow_dispatch` if added later) will validate the Linux build path end-to-end

## Scope

- `release.yml` only. No code, no test, no docs changes.
- Currently-queued v0.4.0 / v0.4.1 / v0.4.2 runs are frozen against the pre-fix workflow and won't benefit. Future tag pushes will use the corrected version.