### PR TITLE
fix: install.sh --verify symlink check resolves through symlinks

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,7 @@
 #
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 CLAUDE_HOME="${CLAUDE_HOME:-$HOME/.claude}"
 PLUGINS_DIR="$CLAUDE_HOME/plugins"
 PLUGIN_LINK="$PLUGINS_DIR/presence"


### PR DESCRIPTION
## Summary

- `install.sh --verify` was failing the symlink check when invoked through `~/.claude/plugins/presence/install.sh --verify` (the supported user path).
- Root cause: `SCRIPT_DIR="$(cd ... && pwd)"` returns the *logical* path; one side of the comparison was the symlink, the other was the resolved target. Switching to `pwd -P` normalizes both sides through symlinks.
- Pre-existing bug; invisible from the repo (`./install.sh --verify` works) because cd into the repo gives the same canonical path either way. Surfaces only when running through the installed symlink.

## Test plan

- [x] `./install.sh --verify` (from repo) - still passes (was already passing)
- [x] `~/.claude/plugins/presence/install.sh --verify` (through symlink) - now passes (was failing)
- [x] `shellcheck install.sh` - clean

No behavior change beyond the verify check itself; install / uninstall / update / bootstrap unaffected.