### PR TITLE
docs: refresh README + llms.txt + adapter docs for v0.5.0 (pre-tag pass)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ State lives in `~/.claude/presence/`, fully local, never uploaded.
 | SessionStart populated | 112 ms median | **9.1 ms median** | 10 KB model + 100 events + 50 claims |
 | Aggregate session (77 fires) | 6.4 s | **770 ms** | n=10 / n=5, `bench/aggregate_session.py` |
 | Install + first /presence-status | 245 ms total | 245 ms total | n=25, `bench/install_to_working.py` |
-| Tests | 240 passing | | Python 3.12 + 3.13 + 3.14 across Linux + macOS |
+| Tests | 291 passing | | Python 3.12 + 3.13 + 3.14 across Linux + macOS |
 | Runtime deps (default) | 0 (stdlib only) | | one optional: `cryptography` for Zero-Trust at-rest encryption |
 | Optional with `--build-ext` | | Rust toolchain at install time | binary then runs without Rust |
-| Surface area | 4 presets, 6 hooks, 6 slash commands, 3 skills, 1 subagent, 1 MCP server | | (multi-host adapters land in v0.4.2) |
+| Surface area | 4 presets, 6 hooks, 6 slash commands, 3 skills, 1 subagent, 1 MCP server, 1 cross-tool adapter, 3 redaction profiles | | redaction profiles opt-in for regulated workloads |
 | Network egress | 0 in default presets | | opt-in `gh` PR-status call; opt-in `--bootstrap` / `--download-ext`; all disabled by default |
 | Platforms | macOS arm64 + Linux x86_64 (CI) | | Windows: install in WSL2 |
 
@@ -38,6 +38,7 @@ The `--build-ext` column reflects optional native acceleration via the Rust daem
 All measurements: macOS arm64, Python 3.14.4. Reproduce locally with `python3 bench/<name>.py --runs N`. See [`bench/README.md`](bench/README.md) for the full convention.
 
 > **Recent changes**: see [`CHANGELOG.md`](CHANGELOG.md) for the full per-version diff.
+> v0.5.0 ships composable redaction profiles for jurisdiction-aware sensitive data. Opt-in via `redact.profiles` in settings: `pii-eu`, `pii-us`, `pci-dss` (PAN matches gated by Luhn). New `docs/compliance.md` says exactly what presence does and does not do for regulated workloads. No certification framing: profile names describe data classes, not compliance frameworks.
 > v0.4.2 ships the cross-tool AGENTS.md adapter. Set `PRESENCE_HOST=agents-md` and presence refreshes `<repo>/AGENTS.md` on every Claude Code SessionStart, picked up automatically by Codex, Cursor, Gemini CLI, Windsurf, GitHub Copilot, and others reading the open AGENTS.md standard. See [`docs/multi-host.md`](docs/multi-host.md).
 > v0.4.1 shipped the MCP server: any MCP-aware client (Claude Desktop, Cursor, Continue, custom agents) can read presence's living model + outcome telemetry over JSON-RPC stdio. See [`docs/mcp.md`](docs/mcp.md).
 > v0.4.0 shipped the Rust daemon client + warm Python daemon + adapter seam. Optional via `--build-ext` / `--download-ext`. Cuts hot-path latency from 82 ms to 8.9 ms (-89%).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -132,10 +132,10 @@ v0.4.0 routes `_common.emit_context()` through a host-AI-tool adapter:
 - `ClaudeAdapter` (default; v0.4.0 ships only this one) emits the `hookSpecificOutput` JSON shape Claude Code consumes.
 - `PRESENCE_HOST=...` env var selects the adapter at runtime.
 
-Future adapters land later:
+Adapters that have shipped:
 
-- v0.4.1: MCP server (`lib/mcp_server.py`, currently parked) exposes `presence://<repo-id>/model` and `presence://<repo-id>/telemetry` over stdio JSON-RPC. Any MCP-compliant client (Cursor, Claude Desktop, Continue, custom agents) can read presence's living model + outcome telemetry.
-- v0.4.2: per-host adapters for Cursor, Gemini, Codex, claude-code, clawbot, plus a `GenericAdapter` fallback. Each host has its own context-injection mechanism; the adapter pattern is the seam where that knowledge lives.
+- v0.4.1: MCP server (`lib/mcp_server.py`) exposes `presence://<repo-id>/model` and `presence://<repo-id>/telemetry` over stdio JSON-RPC. Any MCP-compliant client (Cursor, Claude Desktop, Continue, custom agents) can read presence's living model + outcome telemetry.
+- v0.4.2: cross-tool AGENTS.md adapter (`AgentsMdAdapter`) refreshes `<repo>/AGENTS.md` on SessionStart so Codex, Cursor, Gemini CLI, Windsurf, GitHub Copilot, and other tools reading the open AGENTS.md standard pick up presence's context. Plus `GenericAdapter` for debugging. Per-host classes turned out to be unnecessary because AGENTS.md serves all of them; one `PRESENCE_AGENTS_MD_FILENAME` override covers tool-specific filenames.
 
 The seam is the v1.0 architectural goal from roadmap issue #8 brought forward to v0.4.x because the cloud-agent prototype already proved the pattern works.
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -99,7 +99,7 @@ The server resolves `<repo_id>` from the current working directory at the time o
 1. Launch a separate instance per project (set the working directory in the MCP client config), or
 2. Pass `cwd` via the MCP client's per-server config field if it has one.
 
-This is a known limitation of the v0.4.1 implementation. v0.4.2 may add an explicit `repo_id` parameter to `resources/read` for clients that want to switch repos without restarting the server.
+This is a known limitation of the v0.4.1 implementation. A future minor may add an explicit `repo_id` parameter to `resources/read` for clients that want to switch repos without restarting the server.
 
 ## What's NOT exposed
 
@@ -116,5 +116,5 @@ This is a known limitation of the v0.4.1 implementation. v0.4.2 may add an expli
 
 ## Roadmap
 
-- v0.4.2: explicit `repo_id` parameter for cross-repo reads.
+- Future: explicit `repo_id` parameter for cross-repo reads (so a single MCP server instance can serve multiple projects without restart).
 - Future: `resources/subscribe` so MCP clients can watch for new commits / revert detections in real time.

--- a/docs/multi-host.md
+++ b/docs/multi-host.md
@@ -99,8 +99,8 @@ The tradeoffs are the same as for any auto-generated file in version control. pr
 
 - **Per-tool adapters** (Cursor / Gemini / Codex separate classes): unnecessary because AGENTS.md serves all of them. The single override `PRESENCE_AGENTS_MD_FILENAME` covers users who want the tool-specific filename.
 - **Live MCP integration**: that's v0.4.1 (`docs/mcp.md`). MCP-aware tools (Claude Desktop, Cursor, Continue) can use the MCP server for live reads instead of, or in addition to, the AGENTS.md refresh.
-- **ACP** (Agent Client Protocol from Zed): chat-session control, distinct from AGENTS.md's "give me context." Tracked as v0.4.3 / v0.5.0.
-- **`clawbot` adapter**: this tool is not publicly documented in any source verified at the time of v0.4.2; if support is needed, file an issue with a pointer to the spec and we'll add a v0.4.3 patch.
+- **ACP** (Agent Client Protocol from Zed): chat-session control, distinct from AGENTS.md's "give me context." Tracked in `docs/roadmap.md` as a future minor.
+- **`clawbot` adapter**: this tool is not publicly documented in any source verified at the time of v0.4.2; if support is needed, file an issue with a pointer to the spec.
 
 ## Compared to MCP (v0.4.1)
 

--- a/llms.txt
+++ b/llms.txt
@@ -78,7 +78,7 @@ Then in any Claude Code session: `/presence-status` to confirm.
 ## Key files
 
 - `README.md` - full project overview, install, presets, privacy, disclaimer
-- `CHANGELOG.md` - per-version diff (current: v0.3.1)
+- `CHANGELOG.md` - per-version diff (current: v0.5.0)
 - `install.sh` - idempotent installer (and `--uninstall [--purge]`)
 - `lib/` - all hook entry points and shared helpers (stdlib-only)
 - `hooks/scripts/` - bash wrappers for the 6 hook events


### PR DESCRIPTION
## Summary

Pre-tag freshness sweep before tagging v0.5.0. Five user-facing docs had stale version references that pre-dated v0.5.0 and would have shipped in the GitHub Release as-is.

- **README.md**: Tests row 240 -> 291; Surface area row drops obsolete "(multi-host adapters land in v0.4.2)" and adds 1 cross-tool adapter + 3 redaction profiles; "Recent changes" callout gains a v0.5.0 line.
- **llms.txt**: "current: v0.3.1" -> "current: v0.5.0".
- **docs/architecture.md**: replaces a speculative "Future adapters land later" block (written at v0.4.0) with what actually shipped at v0.4.1 / v0.4.2.
- **docs/multi-host.md**: ACP version pinning ("tracked as v0.4.3 / v0.5.0") -> "future minor"; drops a clawbot v0.4.3 pre-promise.
- **docs/mcp.md**: two v0.4.2 forward-references (repo_id parameter / cross-repo reads) that didn't ship -> "future minor".

No code or behavior changes. `plugin.json` and `lib/__init__.py` already report 0.5.0; `ext/Cargo.toml` stays at 0.1.0 (no `ext/` changes since v0.4.2 per the ext-versioning memory rule).

## Test plan

- [x] `grep -rnE "v0\.[34]\.[0-9]+"` across user-facing docs - remaining hits are all valid historical references (describing when each feature shipped), not stale forward-looking ones.