### PR TITLE
fix(ext): enable secret-service rt-async-io-crypto-rust feature for Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ The hard rule for this release is what is NOT shipping: no preset named after a 
 - 291 tests passing on Python 3.12 / 3.13 / 3.14 (was 256 in v0.4.2; +27 from `test_redact_profiles.py`, +3 from `test_telemetry.py`, +1 from `test_post_tool_bash.py`, +2 from `test_zerotrust_integration.py` covering the regulated-workload e2e path: zerotrust + `redact.profiles=["pii-eu"]` -> IBAN redacted before encryption + negative control without the profile).
 - MANIFEST regenerated and verifies; the `presets/redaction/*.json` profiles are SHA-256 covered by zerotrust integrity.
 
+### Native extension
+
+- `ext/Cargo.toml` 0.1.0 -> 0.1.1: secret-service 3.x has no default async-runtime feature, so the Linux Rust build was failing transitively on zbus (`async_fs` / `async_io` / `blocking` modules unresolved). Pinned `features = ["rt-async-io-crypto-rust"]` so zbus compiles with its async-io backend. macOS path unchanged. Local macOS builds never exercised this because the `cfg(target_os = "linux")` deps are not resolved on macOS; the failure surfaced on the first real CI Linux Rust build during the v0.5.0 release.
+
 ## v0.4.2
 
 Cross-tool AGENTS.md adapter. Closes roadmap issue #8 (multi-AI-tool support).

--- a/ext/Cargo.lock
+++ b/ext/Cargo.lock
@@ -3,6 +3,17 @@
 version = 4
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -37,6 +48,32 @@ dependencies = [
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497c00e0fd83a72a79a39fcbd8e3e2f055d6f6c7e025f3b3d91f4f8e76527fb8"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand 2.4.1",
+ "futures-lite 2.6.1",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-fs"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "279cf904654eeebfa37ac9bb1598880884924aab82e290aa65c9e77a0e142e06"
+dependencies = [
+ "async-lock 2.8.0",
+ "autocfg",
+ "blocking",
+ "futures-lite 1.13.0",
 ]
 
 [[package]]
@@ -194,6 +231,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "blocking"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -213,6 +259,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,6 +284,16 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
 
 [[package]]
 name = "concurrent-queue"
@@ -299,6 +364,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -456,7 +522,10 @@ version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
 dependencies = [
+ "fastrand 2.4.1",
  "futures-core",
+ "futures-io",
+ "parking",
  "pin-project-lite",
 ]
 
@@ -490,9 +559,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -602,6 +673,24 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "icu_collections"
@@ -731,6 +820,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
 ]
 
 [[package]]
@@ -1117,7 +1216,7 @@ dependencies = [
 
 [[package]]
 name = "presence_ext"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "git2",
  "hex",
@@ -1366,12 +1465,16 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5204d39df37f06d1944935232fd2dfe05008def7ca599bf28c0800366c8a8f9"
 dependencies = [
+ "aes",
+ "cbc",
  "futures-util",
  "generic-array",
+ "hkdf",
  "num",
  "once_cell",
  "rand",
  "serde",
+ "sha2",
  "zbus",
 ]
 
@@ -1470,6 +1573,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1518,6 +1632,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -2083,9 +2203,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "675d170b632a6ad49804c8cf2105d7c31eddd3312555cffd4b740e08e97c25e6"
 dependencies = [
  "async-broadcast",
+ "async-executor",
+ "async-fs",
+ "async-io 1.13.0",
+ "async-lock 2.8.0",
  "async-process",
  "async-recursion",
+ "async-task",
  "async-trait",
+ "blocking",
  "byteorder",
  "derivative",
  "enumflags2",

--- a/ext/Cargo.toml
+++ b/ext/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "presence_ext"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [lib]
@@ -24,7 +24,13 @@ pyext = ["pyo3"]
 security-framework = "2.9"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-secret-service = "3.0"
+# secret-service 3.x has no default async-runtime feature; without one of
+# rt-async-io-crypto-{rust,openssl} or rt-tokio-crypto-{rust,openssl},
+# zbus compiles without its async backend and the build fails referencing
+# missing async_fs / blocking / async_io modules. Picking the rust-crypto
+# async-io variant keeps us on a single async runtime (we already use
+# async-io transitively elsewhere) and avoids dragging in OpenSSL.
+secret-service = { version = "3.0", features = ["rt-async-io-crypto-rust"] }
 
 [dependencies.git2]
 version = "0.18"


### PR DESCRIPTION
## Summary

The Linux Rust build of \`presence-client\` failed during the v0.5.0 release matrix with 17 errors compiling \`zbus 3.15.2\`: missing modules \`async_fs\` / \`async_io\` / \`blocking\`. Root cause: \`secret-service 3.x\` has no default async-runtime feature; without explicitly enabling one (\`rt-async-io-crypto-rust\` / \`rt-async-io-crypto-openssl\` / \`rt-tokio-crypto-rust\` / \`rt-tokio-crypto-openssl\`), \`zbus\` is pulled in with \`default-features = false\` and its code references modules that only exist when the async backend feature is on.

Picked **\`rt-async-io-crypto-rust\`** because (a) presence already uses \`async-io\` transitively, so the feature is unified rather than adding a second async runtime; (b) \`crypto-rust\` avoids dragging in OpenSSL (smaller binary, fewer system deps).

The bug was invisible on macOS because the dep is gated behind \`cfg(target_os = "linux")\` and never resolves on a macOS build. First real CI Linux Rust build (the v0.5.0 release attempt) is where it surfaced.

\`ext/Cargo.toml\` 0.1.0 -> 0.1.1 per the ext-versioning rule. \`ext/Cargo.lock\` now has \`aes\` / \`cbc\` / \`hkdf\` / \`sha2\` / \`async-io\` / \`async-fs\` / \`blocking\` entries. \`CHANGELOG.md\` picks up a "Native extension" subsection under v0.5.0 (v0.5.0 hasn't released yet; the broken tag was deleted, this fix lands before the retag).

## Test plan

- [x] Local macOS arm64 build still clean (\`cargo build --release --bin presence-client --no-default-features --target aarch64-apple-darwin\`)
- [x] \`Cargo.lock\` updated to reflect the now-enabled feature graph
- [x] CI build matrix proves the fix on Linux x86_64 (PR run)