### PR TITLE
ci(release): cross-compile x86_64-apple-darwin from arm64 runner (drops macos-13 dependency)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,13 @@ jobs:
             os: ubuntu-latest
             artifact: presence-client-linux-x86_64
           - target: x86_64-apple-darwin
-            os: macos-13   # Intel runner
+            # Cross-compile from arm64. macos-13 (Intel) runner pool is
+            # chronically congested; v0.4.0 / v0.4.1 / v0.4.2 / v0.5.0 attempts
+            # all stalled in the Intel queue. Apple's clang on macos-latest
+            # (arm64) produces x86_64 mach-o binaries via the universal SDK;
+            # the toolchain action's targets: input below installs the
+            # x86_64-apple-darwin target. One runner pool, no Intel queue.
+            os: macos-latest
             artifact: presence-client-macos-x86_64
           - target: aarch64-apple-darwin
             os: macos-latest


### PR DESCRIPTION
## Summary

GitHub's macos-13 (Intel) runner pool is chronically congested. Every \`release.yml\` run since v0.4.0 has stalled in the macOS Intel queue:

- v0.4.0 / v0.4.1 / v0.4.2 release runs: cancelled after macOS Intel sat queued for hours.
- v0.5.0 attempt 1: cancelled (Linux failed unrelatedly, Intel queued).
- v0.5.0 attempt 2 (after the ext fix): Linux + arm64 finished in under 2 minutes; macOS Intel sat queued for 13+ minutes; cancelled to unblock the publish step.

Root cause is GitHub-side: macos-13 is the only Intel-equipped GitHub-hosted image left, capacity is deprioritized, and queue depth is unbounded.

**Fix:** build x86_64-apple-darwin via cross-compile from \`macos-latest\` (arm64) instead of allocating a separate macos-13 runner. Apple's clang on Apple Silicon supports producing x86_64 mach-o binaries through the universal macOS SDK; \`dtolnay/rust-toolchain@stable\` with \`targets: \${{ matrix.target }}\` already installs \`x86_64-apple-darwin\` on whatever runner it's invoked on. One macOS runner pool, no more Intel queue.

The git2 / libgit2 / Security.framework deps are universal SDK frameworks - no system library install needed (in contrast to the Linux build). \`presence_ext\`'s Cargo.toml selects the correct \`target_os = "macos"\` deps regardless of build host arch.

## Verification

- [x] Locally cross-compiled \`x86_64-apple-darwin\` from my arm64 mac with the same flags release.yml uses (\`cargo build --release --bin presence-client --no-default-features --target x86_64-apple-darwin\`); produced a valid Mach-O 64-bit executable for x86_64 in 16 seconds.
- [x] Binary has been uploaded to the v0.5.0 release as a backfill so v0.5.0 has the full asset set even before this PR merges.
- [ ] Next tag (v0.5.1 or later) exercises the cross-compile path on CI.

## Why now

Linking this PR with PR #25 (docs) finishes the v0.5.0 cleanup. v0.5.0 itself shipped (Linux + arm64 + manually-uploaded x86_64 macOS); future tags will have all three architectures built automatically without depending on the unmaintained Intel runner pool.