### PR TITLE
v0.5.1: release patch (cuts complete asset matrix; fixes README install-flow accuracy)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "presence",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Continuous-collaboration layer for Claude Code: living project model, outcome telemetry, event digest, and calibrated confidence. Fully local, install-once, applies to every project.",
   "author": {
     "name": "Sara Star Quant LLC"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## v0.5.1
+
+Release-only patch. No code or behavior changes vs. v0.5.0; this tag exists to produce a complete release-asset matrix on the new CI cross-compile path.
+
+### Why
+
+The v0.5.0 release shipped with two binaries (`presence-client-linux-x86_64`, `presence-client-macos-arm64`) but not the third (`presence-client-macos-x86_64`). GitHub's `macos-13` (Intel) runner pool stalled in queue for 13+ minutes during the v0.5.0 build matrix, the run was cancelled to unblock the publish step, and the Intel binary never built. The same Intel-pool stall has cancelled every `release.yml` run since v0.4.0.
+
+v0.5.1 retags the same code as v0.5.0 + the cross-compile fix that landed on main between the two tags. The new matrix builds `x86_64-apple-darwin` from a `macos-latest` (arm64) runner via Apple's universal SDK, eliminating the macos-13 dependency entirely.
+
+### What changed since v0.5.0
+
+- `release.yml`: x86_64-apple-darwin matrix entry now uses `os: macos-latest` and cross-compiles via `dtolnay/rust-toolchain@stable` with `targets: ${{ matrix.target }}`. One macOS runner pool for both architectures.
+- `README.md`: tagline names the MCP + AGENTS.md projections precisely (cross-tool reach was undersold by the Claude-Code-only framing). New "Install (30 seconds)" block above the perf table. Cryptography install replaces the bare `pip install --user cryptography` (which fails on PEP 668 externally-managed Pythons) with three labeled paths: uv-managed, `--break-system-packages`, dedicated venv.
+- `docs/roadmap.md`: new "Universal install: paths beyond Claude Code-only" entry as decision history for the three universality paths (daemon mode / per-tool plugins / editor extension), all deferred with stated criteria for revisiting.
+- `README.md` Quickstart: the no-Python-3.12+ behavior was previously documented as "the installer prints a clear message and exits"; the actual `install.sh` behavior (line 44) is "warn and continue, presence stays inactive until Python is available". Doc now matches the implementation.
+- Repository metadata: description rewritten to mention MCP + AGENTS.md projections; topics gain `mcp`, `mcp-server`, `agents-md`, `compliance-redaction`.
+
+### Verification
+
+- 291 tests pass (unchanged from v0.5.0).
+- Manifest verifies; the `presets/redaction/*.json` profiles remain SHA-256 covered.
+- The v0.5.1 release will be the first to ship a `presence-client-macos-x86_64` artifact built from CI on the new cross-compile matrix.
+
 ## v0.5.0
 
 Composable redaction profiles for jurisdiction-aware sensitive-data handling.

--- a/MANIFEST.lock
+++ b/MANIFEST.lock
@@ -2,7 +2,7 @@
   "_format": 1,
   "files": {
     ".claude-plugin/marketplace.json": "066ae0d198f750ebfb7b1df4d1b2dffc3db01030d8c5d5865be0064c007c79ff",
-    ".claude-plugin/plugin.json": "4dbf05c11ef2646186666eedf697cb97395cf566a0723327735481d3b2764898",
+    ".claude-plugin/plugin.json": "8ba8643dfae9ee94da3852f0bf0cc8bc61531c6ada99538aee9147d104fae625",
     "agents/model-curator.md": "1b8381997ea4c29944e1388b7467ca38787c893801e8bfd79460c103d0e169d5",
     "commands/presence-bugreport.md": "dfa35b61dfcf30f0f268fb0c8fed6dbd92f7da058fca34f07b9beab8a52ddf79",
     "commands/presence-curate.md": "9295204486515a9dfd1a66ee77b64b067fdcb04ca436f182106659b33d504986",
@@ -19,7 +19,7 @@
     "hooks/scripts/session-start.sh": "8d1c7ae9ae0884fb88bc9e18f949dc9d5bd1c3ce1aff40da14088128917b09fb",
     "hooks/scripts/stop.sh": "54ead2f0f29aefcf9120f44f99f9c7f5357fbbacc9330d28e942200947595267",
     "hooks/scripts/user-prompt-submit.sh": "006cc582419f061934dc94842de6240722b48ac23578c1b0c84ae1ceaad6df60",
-    "lib/__init__.py": "032795fe4a7259ae172ea753c3b1af3141c354309f0fc2dd1307bfb323a1e18b",
+    "lib/__init__.py": "ac3b61bc511aebccee55c57686b7ae2b9272f8467468261d36c8f35189ec2701",
     "lib/_common.py": "207cbcc6d0327aafd8cbea6f666564e2d2d937c2c54473fe03803b7e09300e95",
     "lib/audit.py": "d71dada0ad335a0495e17afd04bbcb2f7c6e81fd163d8d3036ba83b5dbc1fa2a",
     "lib/bugreport.py": "6d1f518382e33e032dedff37a4007c7dcc1d7a196100431d86f1d48c36f049fd",

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ curl -fsSL https://raw.githubusercontent.com/sara-star-quant/presence/main/insta
 
 The installer is idempotent. It checks for Python 3.12+, symlinks the plugin into `~/.claude/plugins/presence`, creates the state directory at `~/.claude/presence/` with `0700` perms, generates `MANIFEST.lock`, and pre-compiles `lib/` to bytecode.
 
-If you don't have Python 3.12+, the installer prints a clear message and exits. To auto-install Python 3.13 via [uv](https://github.com/astral-sh/uv) (single binary, no sudo, ~5 MB), pass `--bootstrap`:
+If you don't have Python 3.12+, the installer prints a warning and continues; presence is installed but stays inactive until a 3.12+ Python is on `PATH`. This is intentional so you can install on a machine that will get Python later (or run `--bootstrap`). To auto-install Python 3.13 via [uv](https://github.com/astral-sh/uv) (single binary, no sudo, ~5 MB), pass `--bootstrap`:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/sara-star-quant/presence/main/install.sh | bash -s -- --bootstrap

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -1,2 +1,2 @@
 """presence: continuous-collaboration layer for Claude Code."""
-__version__ = "0.5.0"
+__version__ = "0.5.1"


### PR DESCRIPTION
## Summary

Release-only patch. Same code as v0.5.0 + the release.yml cross-compile fix already on main. Tagged so the next release.yml run builds the full asset matrix (Linux + macOS arm64 + macOS x86_64) on the new `macos-latest`-only path, eliminating the chronic Intel-runner queue stall.

### Why a v0.5.1 instead of retag-v0.5.0

v0.5.0 already shipped publicly with two binaries (`presence-client-linux-x86_64`, `presence-client-macos-arm64`). Force-rewriting that tag to add the third architecture would invalidate any pin against v0.5.0. v0.5.1 is the right semver: same features, different release artifacts, additive history.

### What's new since v0.5.0

- `.claude-plugin/plugin.json` + `lib/__init__.py`: `0.5.0` -> `0.5.1`.
- `README.md` Quickstart: small accuracy fix. The doc said "If you don't have Python 3.12+, the installer prints a clear message and exits." `install.sh` actually warns and continues; presence is installed but inactive until Python 3.12+ is available. Doc now matches implementation.
- `CHANGELOG.md`: `## v0.5.1` entry.
- `MANIFEST.lock` regenerated.

No code changes. 291 tests pass unchanged. The full v0.5.0 feature set (composable redaction profiles, Luhn, `docs/compliance.md`, `/presence-doctor` redact section, `python3 -m redact` CLI) is unchanged.

### Post-merge

Tag `v0.5.1` from main HEAD. `release.yml` fires on the new matrix and publishes all three architectures from one macOS runner pool.