### PR TITLE
v0.5.2: ext: disable git2 default features so x86_64 cross-compile works

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "presence",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Continuous-collaboration layer for Claude Code: living project model, outcome telemetry, event digest, and calibrated confidence. Fully local, install-once, applies to every project.",
   "author": {
     "name": "Sara Star Quant LLC"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## v0.5.2
+
+Release-only patch. Same code as v0.5.1 + a `git2` feature fix that lets the cross-compile matrix actually produce the macOS x86_64 binary.
+
+### Why
+
+v0.5.1 was supposed to ship the full Linux + macOS arm64 + macOS x86_64 asset set on the new cross-compile path that v0.5.0 introduced. The Linux + arm64 builds succeeded; the x86_64 cross-compile failed during `openssl-sys` build because `git2`'s default features include `https`, which pulls `openssl-sys`. On the macos-latest (arm64) runner the host's OpenSSL is arm64-only, so the x86_64 target build couldn't find the right libraries. v0.5.0 + v0.5.1 each shipped with two binaries instead of three because of this same issue (different symptoms, same root cause).
+
+### What changed since v0.5.1
+
+- `ext/Cargo.toml`: `git2 = { version = "0.18", default-features = false }`. presence is local-only - we use `git2` only for read-only repo introspection (`Repository`, `Sort`, log walk, HEAD resolution). No HTTPS, no SSH, no network git ops. Disabling defaults removes the `openssl-sys` dependency entirely; cross-compilation from arm64 to x86_64 macOS now succeeds without needing target-arch OpenSSL libraries on the host.
+- `ext/Cargo.toml`: ext crate `0.1.1` -> `0.1.2` per the ext-versioning rule (any `ext/` source change bumps the crate version).
+- `.claude-plugin/plugin.json` + `lib/__init__.py`: `0.5.1` -> `0.5.2`.
+
+### Verified locally
+
+- `cargo build --release --bin presence-client --no-default-features --target x86_64-apple-darwin` from arm64 mac produces `Mach-O 64-bit executable x86_64` in 10 seconds.
+- `cargo build --release --bin presence-client --no-default-features --target aarch64-apple-darwin` still produces `Mach-O 64-bit executable arm64` in 10 seconds.
+- 291 tests pass unchanged.
+
+### What is unchanged
+
+- All v0.5.0 features: composable redaction profiles, Luhn validator, `docs/compliance.md`, `/presence-doctor` redact section, `python3 -m redact` CLI.
+- All v0.5.1 doc fixes: README install-flow correction, multi-tool framing, universal-install roadmap entry.
+- No code under `lib/`, `hooks/`, `presets/`, `tests/`. Pure Cargo dep configuration.
+
 ## v0.5.1
 
 Release-only patch. No code or behavior changes vs. v0.5.0; this tag exists to produce a complete release-asset matrix on the new CI cross-compile path.

--- a/MANIFEST.lock
+++ b/MANIFEST.lock
@@ -2,7 +2,7 @@
   "_format": 1,
   "files": {
     ".claude-plugin/marketplace.json": "066ae0d198f750ebfb7b1df4d1b2dffc3db01030d8c5d5865be0064c007c79ff",
-    ".claude-plugin/plugin.json": "8ba8643dfae9ee94da3852f0bf0cc8bc61531c6ada99538aee9147d104fae625",
+    ".claude-plugin/plugin.json": "3fa59f3d1ff28e24e2cfd43df63e3326738550013593fd913cdcdac6cca93e13",
     "agents/model-curator.md": "1b8381997ea4c29944e1388b7467ca38787c893801e8bfd79460c103d0e169d5",
     "commands/presence-bugreport.md": "dfa35b61dfcf30f0f268fb0c8fed6dbd92f7da058fca34f07b9beab8a52ddf79",
     "commands/presence-curate.md": "9295204486515a9dfd1a66ee77b64b067fdcb04ca436f182106659b33d504986",
@@ -19,7 +19,7 @@
     "hooks/scripts/session-start.sh": "8d1c7ae9ae0884fb88bc9e18f949dc9d5bd1c3ce1aff40da14088128917b09fb",
     "hooks/scripts/stop.sh": "54ead2f0f29aefcf9120f44f99f9c7f5357fbbacc9330d28e942200947595267",
     "hooks/scripts/user-prompt-submit.sh": "006cc582419f061934dc94842de6240722b48ac23578c1b0c84ae1ceaad6df60",
-    "lib/__init__.py": "ac3b61bc511aebccee55c57686b7ae2b9272f8467468261d36c8f35189ec2701",
+    "lib/__init__.py": "ae55d73eac60c8864c7bcc449de8dfa8f3da23c3cefda1df06434668da36db27",
     "lib/_common.py": "207cbcc6d0327aafd8cbea6f666564e2d2d937c2c54473fe03803b7e09300e95",
     "lib/audit.py": "d71dada0ad335a0495e17afd04bbcb2f7c6e81fd163d8d3036ba83b5dbc1fa2a",
     "lib/bugreport.py": "6d1f518382e33e032dedff37a4007c7dcc1d7a196100431d86f1d48c36f049fd",

--- a/ext/Cargo.lock
+++ b/ext/Cargo.lock
@@ -624,8 +624,6 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
- "openssl-probe",
- "openssl-sys",
  "url",
 ]
 
@@ -888,24 +886,8 @@ checksum = "ee4126d8b4ee5c9d9ea891dd875cfdc1e9d0950437179104b183d7d8a74d24e8"
 dependencies = [
  "cc",
  "libc",
- "libssh2-sys",
  "libz-sys",
- "openssl-sys",
  "pkg-config",
-]
-
-[[package]]
-name = "libssh2-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "220e4f05ad4a218192533b300327f5150e809b54c4ec83b5a1d91833601811b9"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -1075,24 +1057,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
-name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.114"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "ordered-stream"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1216,7 +1180,7 @@ dependencies = [
 
 [[package]]
 name = "presence_ext"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "git2",
  "hex",

--- a/ext/Cargo.toml
+++ b/ext/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "presence_ext"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 [lib]
@@ -33,4 +33,14 @@ security-framework = "2.9"
 secret-service = { version = "3.0", features = ["rt-async-io-crypto-rust"] }
 
 [dependencies.git2]
+# default-features disabled because git2's defaults pull in openssl-sys
+# (via the `https` feature) for HTTPS git operations. presence is local-only;
+# we use git2 only for read-only repo introspection (Repository + Sort in
+# ext/src/git.rs - log walk, HEAD resolution, blame). No network ops, no
+# HTTPS, no SSH. Disabling defaults eliminates the openssl-sys requirement
+# that otherwise breaks cross-compilation from arm64 -> x86_64 macOS where
+# the host's OpenSSL paths don't match the target architecture. Without
+# this, release.yml's x86_64-apple-darwin build fails on the macos-latest
+# (arm64) runner trying to find x86_64 OpenSSL.
 version = "0.18"
+default-features = false

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -1,2 +1,2 @@
 """presence: continuous-collaboration layer for Claude Code."""
-__version__ = "0.5.1"
+__version__ = "0.5.2"


### PR DESCRIPTION
## Summary

v0.5.0 + v0.5.1 each shipped with two binaries (Linux + macOS arm64) instead of three because the macOS x86_64 cross-compile failed during \`openssl-sys\` build. Different symptoms over time, same root cause: \`git2\`'s default features include \`https\`, which transitively requires \`openssl-sys\`. On the \`macos-latest\` (arm64) runner used by release.yml's x86_64-apple-darwin entry, the host's OpenSSL is arm64-only - the openssl-sys build script can't locate x86_64 OpenSSL for the cross-compile target.

Locally on my arm64 mac the cross-compile worked because Homebrew had x86_64 OpenSSL discoverable. CI runners don't.

## Fix

One line in \`ext/Cargo.toml\`:

\`\`\`toml
[dependencies.git2]
version = "0.18"
default-features = false
\`\`\`

presence is local-only - \`git2\` is used in \`ext/src/git.rs\` only for read-only repo introspection (\`Repository\`, \`Sort\`, log walk, HEAD resolution). No HTTPS, no SSH, no network git ops. Disabling defaults removes \`openssl-sys\` entirely; the cross-compile no longer needs target-arch OpenSSL.

## Verified locally

- \`cargo build --target x86_64-apple-darwin\`: produces \`Mach-O 64-bit executable x86_64\` in 10s (was failing in CI).
- \`cargo build --target aarch64-apple-darwin\`: still produces \`Mach-O 64-bit executable arm64\` in 10s (no regression).
- 291 tests pass.

## Version bumps

- \`ext/Cargo.toml\`: ext crate \`0.1.1\` -> \`0.1.2\` (per the ext-versioning rule: any \`ext/\` source change bumps).
- \`.claude-plugin/plugin.json\` + \`lib/__init__.py\`: plugin \`0.5.1\` -> \`0.5.2\`.

## What's unchanged

- Every v0.5.0 feature (redaction profiles, Luhn, docs/compliance.md, redact CLI).
- Every v0.5.1 doc fix.
- No code under \`lib/\`, \`hooks/\`, \`presets/\`, \`tests/\`. Cargo config only.

## Post-merge

Tag \`v0.5.2\` from main HEAD. release.yml fires; this time the x86_64-apple-darwin matrix entry should succeed, producing all three architectures from one macOS runner pool. v0.5.2 will be the first release with a complete asset set since v0.4.x.