### PR TITLE
v0.5.3: ext: pyo3 0.21 -> 0.28 with full Bound API migration (closes #17)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "presence",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Continuous-collaboration layer for Claude Code: living project model, outcome telemetry, event digest, and calibrated confidence. Fully local, install-once, applies to every project.",
   "author": {
     "name": "Sara Star Quant LLC"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## v0.5.3
+
+ext: pyo3 0.21 -> 0.28, full Bound API migration. ext crate 0.1.2 -> 0.1.3.
+
+### Why
+
+pyo3 0.21 (the version in v0.5.0/0.5.1/0.5.2) is two years old and lags Python's release cadence. dependabot opened PR #17 to bump pyo3 0.21 -> 0.24, but a spot-check confirmed two problems with merging it as-is:
+
+1. PR #17 only touched `ext/Cargo.toml` + `ext/Cargo.lock`, not the source. pyo3 0.22+ replaced the GIL-bound reference API (`&PyModule`, `&PyDict`) with the explicit Bound API (`Bound<'_, PyModule>`, `Bound<'_, PyDict>`). Without source changes, the wheel build fails with 15 compile errors. `ci.yml` and `release.yml` did not catch this because neither builds the wheel - both compile only the binary with `--no-default-features` (which excludes pyo3).
+2. pyo3 0.24.1 caps at Python 3.13. presence's CI matrix tests Python 3.14, and most users on Apple Silicon get 3.14 via Homebrew. Picking 0.28 instead (latest stable; supports Python 3.10 through 3.14) avoids both gaps in one bump.
+
+### What changed in `ext/`
+
+- `ext/Cargo.toml`: pyo3 `0.21` -> `0.28`. Crate version `0.1.2` -> `0.1.3` per the ext-versioning rule.
+- `ext/src/lib.rs`: `#[pymodule] fn presence_ext(_py: Python, m: &PyModule)` -> `fn presence_ext(m: &Bound<'_, PyModule>)`. GIL token reachable via `m.py()`. Submodules constructed with `PyModule::new(m.py(), name)` (returns `Bound<PyModule>` directly).
+- `ext/src/git.rs`: `PyDict::new(py)` returns `Bound<PyDict>` directly; conversion to `PyObject` is now `dict.into_any().unbind()` (Bound -> Py<PyAny>). Function return type `PyObject` replaced with `Py<PyAny>` (pyo3 0.28 does not re-export `PyObject` from `prelude`). `register()` takes `&Bound<'_, PyModule>`.
+- `ext/src/crypto.rs`: `register()` signature updated; pyfunction bodies untouched.
+- `ext/Cargo.lock`: regenerated for the pyo3 0.28 dep tree (`once_cell` replaces `parking_lot` in pyo3's internals; `target-lexicon` 0.12 -> 0.13).
+
+### Verification
+
+- `cargo check --release` clean for the pyext feature.
+- `maturin build --release`: produces `presence_ext-0.1.3-cp314-cp314-macosx_11_0_arm64.whl` in 14 seconds.
+- Wheel installed locally on Python 3.14.4: `import presence_ext` works; both `presence_ext.crypto.{get_key,set_key,delete_key}` and `presence_ext.git.{get_head_commit,scan_for_revert}` callable. Functional smoke test against a real repo returns the expected `dict` from `get_head_commit`.
+- `cargo build --release --bin presence-client --no-default-features --target {x86_64,aarch64}-apple-darwin`: still produces correct mach-o binaries (the binary path does not touch pyo3, but the new pyo3 dep should not regress this).
+- 291 tests pass (unchanged from v0.5.2). The Python tests exercise the daemon path that imports `presence_ext.git` for `get_head_commit` / `scan_for_revert`; the new wheel is hit cleanly.
+
+### Closes
+
+- dependabot PR #17 (`bump pyo3 from 0.21.2 to 0.24.1`). Closing in favor of this PR which does the full migration to 0.28 with the source-side Bound API changes that #17 omitted.
+
+### Unchanged
+
+- All v0.5.0 features (composable redaction profiles, Luhn, `docs/compliance.md`, redact CLI).
+- All v0.5.1 / v0.5.2 doc fixes and the cross-compile path.
+- No code under `lib/`, `hooks/`, `presets/`, `tests/`. The Python-side `_common.py` daemon-fallback contract is identical (the wheel exposes the same symbols with identical signatures).
+
 ## v0.5.2
 
 Release-only patch. Same code as v0.5.1 + a `git2` feature fix that lets the cross-compile matrix actually produce the macOS x86_64 binary.

--- a/MANIFEST.lock
+++ b/MANIFEST.lock
@@ -2,7 +2,7 @@
   "_format": 1,
   "files": {
     ".claude-plugin/marketplace.json": "066ae0d198f750ebfb7b1df4d1b2dffc3db01030d8c5d5865be0064c007c79ff",
-    ".claude-plugin/plugin.json": "3fa59f3d1ff28e24e2cfd43df63e3326738550013593fd913cdcdac6cca93e13",
+    ".claude-plugin/plugin.json": "6d9135f00084aeffac9e1e07db48c5e3ef1d10ab59aaec9e00fffeab0d2e9b24",
     "agents/model-curator.md": "1b8381997ea4c29944e1388b7467ca38787c893801e8bfd79460c103d0e169d5",
     "commands/presence-bugreport.md": "dfa35b61dfcf30f0f268fb0c8fed6dbd92f7da058fca34f07b9beab8a52ddf79",
     "commands/presence-curate.md": "9295204486515a9dfd1a66ee77b64b067fdcb04ca436f182106659b33d504986",
@@ -19,7 +19,7 @@
     "hooks/scripts/session-start.sh": "8d1c7ae9ae0884fb88bc9e18f949dc9d5bd1c3ce1aff40da14088128917b09fb",
     "hooks/scripts/stop.sh": "54ead2f0f29aefcf9120f44f99f9c7f5357fbbacc9330d28e942200947595267",
     "hooks/scripts/user-prompt-submit.sh": "006cc582419f061934dc94842de6240722b48ac23578c1b0c84ae1ceaad6df60",
-    "lib/__init__.py": "ae55d73eac60c8864c7bcc449de8dfa8f3da23c3cefda1df06434668da36db27",
+    "lib/__init__.py": "d6c65abbf061bc45d017019f37277d46921410a25c0cee48c27ad4f24cf26521",
     "lib/_common.py": "207cbcc6d0327aafd8cbea6f666564e2d2d937c2c54473fe03803b7e09300e95",
     "lib/audit.py": "d71dada0ad335a0495e17afd04bbcb2f7c6e81fd163d8d3036ba83b5dbc1fa2a",
     "lib/bugreport.py": "6d1f518382e33e032dedff37a4007c7dcc1d7a196100431d86f1d48c36f049fd",

--- a/ext/Cargo.lock
+++ b/ext/Cargo.lock
@@ -644,12 +644,6 @@ checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -812,15 +806,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -925,15 +910,6 @@ name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
-
-[[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
 
 [[package]]
 name = "log"
@@ -1073,29 +1049,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
-]
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1180,7 +1133,7 @@ dependencies = [
 
 [[package]]
 name = "presence_ext"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "git2",
  "hex",
@@ -1221,37 +1174,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.21.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e00b96a521718e08e03b1a622f01c8a8deb50719335de3f60b3b3950f069d8"
+checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
 dependencies = [
- "cfg-if",
- "indoc",
  "libc",
- "memoffset 0.9.1",
- "parking_lot",
+ "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.21.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7883df5835fafdad87c0d888b266c8ec0f4c9ca48a5bed6bbb592e8dedee1b50"
+checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.21.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01be5843dc60b916ab4dad1dca6d20b9b4e6ddc8e15f50c47fe6d85f1fb97403"
+checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1259,9 +1207,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.21.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77b34069fc0682e11b31dbd10321cbf94808394c56fd996796ce45217dfac53c"
+checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1271,11 +1219,11 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.21.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08260721f32db5e1a5beae69a55553f56b99bd0e1c3e6e0a5e8851a9d0f5a85c"
+checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "pyo3-build-config",
  "quote",
@@ -1331,15 +1279,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -1410,18 +1349,6 @@ dependencies = [
  "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "rustversion"
-version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "secret-service"
@@ -1638,9 +1565,9 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"
@@ -1741,12 +1668,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "url"
@@ -2049,7 +1970,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck 0.5.0",
+ "heck",
  "wit-parser",
 ]
 
@@ -2060,7 +1981,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck 0.5.0",
+ "heck",
  "indexmap",
  "prettyplease",
  "syn 2.0.117",

--- a/ext/Cargo.toml
+++ b/ext/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "presence_ext"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 
 [lib]
@@ -13,7 +13,7 @@ path = "src/client.rs"
 
 [dependencies]
 hex = "0.4.3"
-pyo3 = { version = "0.21", features = ["extension-module"], optional = true }
+pyo3 = { version = "0.28", features = ["extension-module"], optional = true }
 serde_json = "1.0.149"
 
 [features]

--- a/ext/src/crypto.rs
+++ b/ext/src/crypto.rs
@@ -108,7 +108,7 @@ fn delete_key(_py: Python) -> bool {
     platform::delete_key()
 }
 
-pub fn register(m: &PyModule) -> PyResult<()> {
+pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(get_key, m)?)?;
     m.add_function(wrap_pyfunction!(set_key, m)?)?;
     m.add_function(wrap_pyfunction!(delete_key, m)?)?;

--- a/ext/src/git.rs
+++ b/ext/src/git.rs
@@ -1,9 +1,12 @@
+// pyo3 0.22+ Bound API: PyDict::new returns Bound<PyDict> directly; convert to
+// Py<PyAny> via .into_any().unbind() (Bound -> Py<PyAny>). register() takes
+// &Bound<'_, PyModule> per the new add_function signature.
 use pyo3::prelude::*;
 use git2::{Repository, Sort};
 use pyo3::types::PyDict;
 
 #[pyfunction]
-fn get_head_commit(py: Python, cwd: &str) -> PyResult<Option<PyObject>> {
+fn get_head_commit(py: Python<'_>, cwd: &str) -> PyResult<Option<Py<PyAny>>> {
     if let Ok(repo) = Repository::open(cwd) {
         if let Ok(head) = repo.head() {
             if let Ok(commit) = head.peel_to_commit() {
@@ -11,7 +14,7 @@ fn get_head_commit(py: Python, cwd: &str) -> PyResult<Option<PyObject>> {
                 dict.set_item("sha", commit.id().to_string())?;
                 dict.set_item("ct", commit.time().seconds())?;
                 dict.set_item("message", commit.message().unwrap_or("").trim())?;
-                return Ok(Some(dict.into()));
+                return Ok(Some(dict.into_any().unbind()));
             }
         }
     }
@@ -19,7 +22,7 @@ fn get_head_commit(py: Python, cwd: &str) -> PyResult<Option<PyObject>> {
 }
 
 #[pyfunction]
-fn scan_for_revert(py: Python, cwd: &str, since_ts: i64, tracked_shas: Vec<String>) -> PyResult<Vec<PyObject>> {
+fn scan_for_revert(py: Python<'_>, cwd: &str, since_ts: i64, tracked_shas: Vec<String>) -> PyResult<Vec<Py<PyAny>>> {
     let mut findings = Vec::new();
     if let Ok(repo) = Repository::open(cwd) {
         if let Ok(mut revwalk) = repo.revwalk() {
@@ -42,7 +45,7 @@ fn scan_for_revert(py: Python, cwd: &str, since_ts: i64, tracked_shas: Vec<Strin
                                 dict.set_item("by", commit.id().to_string())?;
                                 dict.set_item("ts", commit.time().seconds())?;
                                 dict.set_item("message", commit.message().unwrap_or("").trim())?;
-                                findings.push(dict.into());
+                                findings.push(dict.into_any().unbind());
                                 break;
                             }
                         }
@@ -54,7 +57,7 @@ fn scan_for_revert(py: Python, cwd: &str, since_ts: i64, tracked_shas: Vec<Strin
     Ok(findings)
 }
 
-pub fn register(m: &PyModule) -> PyResult<()> {
+pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(get_head_commit, m)?)?;
     m.add_function(wrap_pyfunction!(scan_for_revert, m)?)?;
     Ok(())

--- a/ext/src/lib.rs
+++ b/ext/src/lib.rs
@@ -1,3 +1,6 @@
+// pyo3 0.22+ Bound API: #[pymodule] expects &Bound<'_, PyModule>; the GIL token
+// is reachable via m.py(). Submodules are constructed with PyModule::new which
+// returns Bound<PyModule> directly. See migration notes in CHANGELOG v0.5.3.
 #[cfg(feature = "pyext")]
 use pyo3::prelude::*;
 
@@ -8,14 +11,14 @@ mod git;
 
 #[cfg(feature = "pyext")]
 #[pymodule]
-fn presence_ext(_py: Python, m: &PyModule) -> PyResult<()> {
-    let crypto_mod = PyModule::new(_py, "crypto")?;
-    crypto::register(crypto_mod)?;
-    m.add_submodule(crypto_mod)?;
+fn presence_ext(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    let crypto_mod = PyModule::new(m.py(), "crypto")?;
+    crypto::register(&crypto_mod)?;
+    m.add_submodule(&crypto_mod)?;
 
-    let git_mod = PyModule::new(_py, "git")?;
-    git::register(git_mod)?;
-    m.add_submodule(git_mod)?;
+    let git_mod = PyModule::new(m.py(), "git")?;
+    git::register(&git_mod)?;
+    m.add_submodule(&git_mod)?;
 
     Ok(())
 }

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -1,2 +1,2 @@
 """presence: continuous-collaboration layer for Claude Code."""
-__version__ = "0.5.2"
+__version__ = "0.5.3"


### PR DESCRIPTION
## Summary

Closes dependabot PR #17 (\`bump pyo3 from 0.21.2 to 0.24.1\`). That PR only modified \`Cargo.toml\` + \`Cargo.lock\`; the source-side migration to pyo3's Bound API was missing, leaving the wheel build broken with 15 compile errors. This PR does the full migration and goes to 0.28 (latest stable; supports Python 3.10-3.14) so we are not back at the same crossroad in three months.

### Why CI did not catch #17 being broken

Neither \`ci.yml\` nor \`release.yml\` builds the wheel. Both compile only \`presence-client\` (binary) with \`--no-default-features\`, which excludes pyo3 entirely. The wheel is built only by \`./install.sh --build-ext\` for end users; a broken pyo3 migration would silently fail there. Caught locally with \`maturin build\`.

### Why 0.28 instead of 0.24

- pyo3 0.24.1 caps at Python 3.13; presence's CI matrix tests 3.14 and macOS users on Homebrew default to 3.14.
- 0.21 -> 0.28 is the same kind of migration (Bound API). One bump avoids a follow-up.

### Source changes

- \`ext/src/lib.rs\`: \`#[pymodule] fn(_py: Python, m: &PyModule)\` -> \`fn(m: &Bound<'_, PyModule>)\`. GIL token via \`m.py()\`. Submodules via \`PyModule::new(m.py(), name)\` (returns Bound<PyModule> directly in 0.22+).
- \`ext/src/git.rs\`: \`PyDict::new(py)\` returns \`Bound<PyDict>\`. Conversion to \`Py<PyAny>\` via \`.into_any().unbind()\`. Return type uses \`Py<PyAny>\` directly (\`PyObject\` is no longer re-exported from \`prelude\`). \`register()\` takes \`&Bound<'_, PyModule>\`.
- \`ext/src/crypto.rs\`: \`register()\` signature update; platform-specific bodies untouched.

### Verification (local, Python 3.14.4 / macOS arm64)

- [x] \`cargo check --release\`: clean (no errors, no new warnings).
- [x] \`maturin build --release\`: produces \`presence_ext-0.1.3-cp314-cp314-macosx_11_0_arm64.whl\` in 14s.
- [x] \`pip install ...whl\` + \`import presence_ext\`: succeeds. Both submodules (\`crypto\`, \`git\`) have the expected attributes.
- [x] \`presence_ext.git.get_head_commit(repo_path)\` returns a real \`dict\` with \`sha\` / \`ct\` / \`message\` keys.
- [x] \`cargo build --release --bin presence-client --no-default-features --target {x86_64,aarch64}-apple-darwin\`: still produces correct mach-o binaries (the binary path doesn't touch pyo3, but the new dep should not regress this).
- [x] 291 tests pass.

### Version bumps

- \`ext/Cargo.toml\`: ext crate \`0.1.2\` -> \`0.1.3\` (per the ext-versioning rule).
- \`.claude-plugin/plugin.json\` + \`lib/__init__.py\`: plugin \`0.5.2\` -> \`0.5.3\`.
- \`MANIFEST.lock\` regenerated.

### Closes

- #17 (dependabot 0.21 -> 0.24). Will close after merge with a comment pointing to this PR.

### What's unchanged

All v0.5.0 features. All v0.5.1 / v0.5.2 doc + CI fixes. No code under \`lib/\`, \`hooks/\`, \`presets/\`, \`tests/\`. The Python-side ext fallback contract is identical (same symbols, same signatures); \`lib/_common.py\` and \`lib/telemetry.py\` do not need to change.