### PR TITLE
Roadmap: version-observability + wheel-build-in-CI entries (lessons from PR #17)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -97,3 +97,69 @@ The bar to add an item here is: someone asked, the maintainer thought about it, 
 - "Auto-detect Cursor" or any other heuristic that pretends to be a hook layer. Either the host fires events presence subscribes to, or it does not.
 - Ship a half-rewrite that runs daemon-side telemetry without the calibrated-confidence gate. The four pillars (living model, telemetry, event digest, calibrated confidence) are co-designed; degraded versions get returned by users as "but X doesn't work" issues.
 - Frame any of the existing read-only projections as "install presence on Cursor". A Cursor user does not install presence; a Claude Code user installs presence and a Cursor user reads its projection.
+
+## Version observability and freshness
+
+**Status**: deferred to v0.6.0 (or whenever the next bigger feature ships); designed.
+
+**Today**: presence has version *strings* in five places and **zero runtime checks**:
+
+| Surface | Version string | Runtime exposure | Cross-check |
+|---|---|---|---|
+| `.claude-plugin/plugin.json` | tracked, manifest | Read by Claude Code at install | None |
+| `lib/__init__.py` (`__version__`) | tracked | Importable, but nothing imports it | None |
+| `ext/Cargo.toml` (presence_ext crate) | tracked | Compiled metadata only | None |
+| `presence_ext` Python module | NOT exposed | None | None |
+| `presence-client` binary | NOT exposed (no `--version` flag) | None | None |
+| GitHub Releases (latest) | exists | Not surfaced anywhere in the runtime | None |
+
+Real-world cost of this gap: dependabot PR #17 (April 2026) bumped `pyo3 0.21 -> 0.24` with green CI. The wheel build was actually broken with 15 compile errors; CI did not catch it because neither `ci.yml` nor `release.yml` builds the wheel. A user running `git pull` + forgetting `--build-ext` after the merge would have hit subtly wrong behavior with no diagnostic.
+
+**Why this is one roadmap entry, not several**: the four sub-items below are co-designed; each makes the next more useful. Solving #1 and #2 alone is just cosmetic; #3 is what catches real bugs; #4 is the freshness layer on top. Shipping any one without the others leaves a half-feature.
+
+**Realistic shape, in increasing scope** (each item builds on the prior):
+
+1. **Static version surfaces** (~30 minutes, ext-only).
+   - `ext/src/lib.rs`: add `m.add("__version__", env!("CARGO_PKG_VERSION"))?` inside the `#[pymodule]` body so `presence_ext.__version__` returns the compiled crate version.
+   - `ext/src/client.rs`: add `--version` arg parsing; print `env!("CARGO_PKG_VERSION")` and exit 0.
+   - Bumps ext crate `0.1.x -> 0.2.0` (per the ext-versioning rule; minor bump because new public surface).
+   - **Standalone value**: low. Two new strings users can read but nothing reads them yet.
+
+2. **Doctor cross-check** (~1 hour, lib-only on top of #1).
+   - `lib/doctor.py::report()` adds a `version_observability` block: `plugin_version` (from `lib/__init__.py.__version__`), `ext_version` (from `presence_ext.__version__` if importable, else `None`), `expected_ext_version` (see #3 for where this comes from).
+   - `lib/doctor.py::render()` shows `ext (rust)  : 0.1.3 (expected >= 0.1.3) OK` or `ext (rust)  : not installed (using subprocess fallback)`.
+   - When the ext is installed but older than `expected_ext_version`: `ext (rust)  : 0.1.0 STALE; run install.sh --update --build-ext to refresh`.
+   - **Standalone value**: medium. Users now have one place to check that their wheel matches their Python.
+
+3. **Compatibility bound + SessionStart warn** (~1 hour, lib-only on top of #2).
+   - `lib/__init__.py` adds `_MIN_EXT_VERSION = "0.1.3"` as a constant; the plugin asserts compatibility with any ext crate at-or-above this version. Bumped manually whenever a Python-side change requires a new ext API surface.
+   - `lib/_common.py` adds `check_ext_compat() -> tuple[ok, message]` that imports `presence_ext.__version__`, parses both with the existing `presence_ext` import path, and returns `(False, "...")` on mismatch.
+   - `lib/hook_session_start.py` calls `check_ext_compat()` once per session-start; on mismatch, calls `warn("ext_version_stale", ...)` with a fix hint (`run install.sh --update --build-ext`). Reuses the existing `warnings_log.warn()` infrastructure so the warning surfaces in the standard `/presence-doctor` warnings panel without new UI code.
+   - Fail-open: any import error or unparseable version -> silent, no warning. The fallback to subprocess git is unaffected.
+   - **Standalone value**: high. This is what would have caught the PR #17 silent-stale-wheel scenario described above.
+
+4. **Network freshness check (opt-in, cached, fail-open)** (~3 hours, new surface).
+   - One outbound call to `https://api.github.com/repos/sara-star-quant/presence/releases/latest` with a 30-second timeout. Returns the highest-semver release tag.
+   - Default OFF in every shipped preset, including non-zerotrust ones. Enabled via `update_check.enabled: true` in user settings; zerotrust preset hard-codes this to false (the same way `outcome_check.enabled` is forced off).
+   - Cache: `~/.claude/presence/.update_check_cache.json` with TTL 24h. Schema: `{"checked_at": "ISO8601", "latest_tag": "v0.6.0", "current_tag": "v0.5.3"}`.
+   - Surfacing: `/presence-doctor` shows `latest release: v0.6.0 (you have v0.5.3)`. NOT surfaced in SessionStart (too noisy). NOT a blocking gate; never refuses to run.
+   - Fail-open: any network/DNS/parse error -> cache stays stale, doctor shows "(check failed)", no warning. Hooks never break on this.
+   - **Standalone value**: medium. Users who run `/presence-doctor` get notified of new releases without leaving Claude Code.
+
+**Why all four are deferred to v0.6.0 (or later)**:
+
+- v0.5.x has been a release-only stabilization line: redaction profiles (v0.5.0), CHANGELOG-and-doc accuracy (v0.5.1), CI cross-compile fixes (v0.5.2), pyo3 migration (v0.5.3). Adding new public surface mid-stabilization-line breaks the "no behavioral change for v0.5.x users" contract.
+- Items #1 + #2 are tiny but only useful with #3, which adds a settings-file constant and a SessionStart codepath; that is a v-minor change.
+- Item #4 introduces network egress (opt-in but new surface) and a settings key (`update_check.enabled`); definitely v-minor.
+
+**Decision criterion**: ship together as a single PR or PR-pair when (a) we have a v0.6.0 anchor feature that justifies the minor bump, OR (b) a user reports a "I ran git pull but presence_ext is stale and behaves wrong" incident that #3 would have caught.
+
+**Implementation order if/when it ships**: #1 -> #2 -> #3 -> #4. Each step is independently testable; the wheel build can be exercised locally with `maturin build` to confirm `presence_ext.__version__` is correct, then `/presence-doctor` smoke-tests #2 and #3, then settings-toggle exercises #4.
+
+**What we will NOT do as a workaround**:
+
+- **Auto-update.** presence never modifies its own install. The user runs `install.sh --update` deliberately. Anything that pulls a new version mid-session is out of scope.
+- **Block hooks on a stale ext.** The fallback-to-subprocess path in `lib/telemetry.py::get_head_commit` and `lib/crypto.py` already handles the "no ext" case silently; "stale ext" should warn but never block.
+- **Cross-check at every hook fire.** SessionStart only. The cost of importing `presence_ext` and parsing `__version__` is microseconds, but doing it 6+ times per turn adds up and the result rarely changes within a session.
+- **Hit GitHub on every SessionStart.** Cache TTL is the whole point; without it we drown the API in requests across the user base.
+- **Mark presence "incompatible" on minor pyo3 bumps.** `_MIN_EXT_VERSION` is a runtime check between *our* plugin Python and *our* ext crate, not a check on pyo3 itself. The pyo3 version is internal to the ext.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -163,3 +163,87 @@ Real-world cost of this gap: dependabot PR #17 (April 2026) bumped `pyo3 0.21 ->
 - **Cross-check at every hook fire.** SessionStart only. The cost of importing `presence_ext` and parsing `__version__` is microseconds, but doing it 6+ times per turn adds up and the result rarely changes within a session.
 - **Hit GitHub on every SessionStart.** Cache TTL is the whole point; without it we drown the API in requests across the user base.
 - **Mark presence "incompatible" on minor pyo3 bumps.** `_MIN_EXT_VERSION` is a runtime check between *our* plugin Python and *our* ext crate, not a check on pyo3 itself. The pyo3 version is internal to the ext.
+
+## Wheel build in CI
+
+**Status**: deferred; designed. Implementation is a single new job in `.github/workflows/ci.yml`; can land in any patch release.
+
+**Today**: `.github/workflows/ci.yml` has 4 jobs: `test` (Python 3.12 / 3.13 / 3.14 x ubuntu-latest / macos-latest = 6 cells), `shellcheck`, `manifest-integrity`, `bench`. None build the `presence_ext` wheel. `release.yml` builds the `presence-client` binary on tag push for 3 architectures (Linux x86_64 + macOS arm64 + macOS x86_64 cross-compile post v0.5.2) but also does not build the wheel. The wheel build only happens locally via `./install.sh --build-ext` for end users (line 461 of install.sh: `maturin build --release --out target/wheels`).
+
+**The gap**: dependabot PR #17 (April 2026) bumped `pyo3 0.21 -> 0.24` with green CI on all 6 test cells + shellcheck + manifest + bench. The wheel build was actually broken with 15 compile errors from the missing Bound API migration. CI did not catch this because no job exercises `maturin build` or any pyext-feature-enabled cargo build. The breakage was caught locally with `maturin build` during PR review (see v0.5.3 / PR #29). A non-vigilant maintainer who trusted CI green would have merged a wheel-broken plugin.
+
+**Realistic shape**: one new job in `.github/workflows/ci.yml`:
+
+```yaml
+wheel-build:
+  name: wheel build (${{ matrix.os }})
+  strategy:
+    fail-fast: false
+    matrix:
+      os: [ubuntu-latest, macos-latest]
+  runs-on: ${{ matrix.os }}
+  steps:
+    - uses: actions/checkout@v5
+    - uses: actions/setup-python@v6
+      with:
+        python-version: "3.13"
+    - uses: dtolnay/rust-toolchain@stable
+    - name: Install Linux system libraries
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends \
+          pkg-config libssh2-1-dev libssl-dev zlib1g-dev
+    - name: Cache cargo registry + ext target
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          ext/target
+        key: wheel-build-${{ matrix.os }}-${{ hashFiles('ext/Cargo.lock') }}
+    - name: Install maturin
+      run: pip install maturin
+    - name: Build wheel
+      run: cd ext && maturin build --release --out target/wheels
+    - name: Smoke-test the wheel
+      run: |
+        WHEEL=$(find ext/target/wheels -name '*.whl' -type f | head -1)
+        pip install --force-reinstall "$WHEEL"
+        python3 -c "
+        import presence_ext
+        head = presence_ext.git.get_head_commit('.')
+        assert head is None or 'sha' in head, f'unexpected get_head_commit shape: {head}'
+        print('wheel smoke-test ok')
+        "
+```
+
+**Three things this catches that current CI does not**:
+
+1. Bound API breakage from any pyo3 / pyext-feature-gated dep bump.
+2. Platform-specific build failures in the wheel path (e.g., a future `secret-service` regression that affects only Linux's `cfg(target_os = "linux")` branch). The Linux + macOS cells together cover both `cfg` branches in `ext/src/crypto.rs`.
+3. Dynamic-link / ABI mismatches that compile-time misses but `import presence_ext` catches.
+
+**Cost**: ~2-4 minutes per PR (two parallel cells, ~1-2 min each on warm cache). First-run on a clean cache is ~3-4 min for libgit2-sys + zbus + secret-service compilation. The cargo registry cache (above) makes the warm-path closer to ~30 seconds. Acceptable for a gate that catches a class of bug current CI misses entirely.
+
+**Why deferred** (and shorter than the version-observability deferral above):
+
+- It is a CI workflow change, not a code change. Lower risk profile; could ship in any patch release.
+- It is partially redundant with item #2 (doctor cross-check) of the version-observability entry: doctor catches the issue post-install on the user's machine, wheel-CI catches it pre-merge. They are complementary; shipping wheel-CI first does not block the version-observability work and vice versa.
+- The deferral is a "small queue item" not a "needs design call". The only design questions (matrix shape, smoke-test depth, cache strategy) are answered above.
+
+**Decision criterion**: ship when (a) the next pyo3 / pyext-gated dep bump is on the horizon (proactive defense; dependabot will eventually open the next pyo3 bump), OR (b) anyone refactors `ext/src/{lib,git,crypto}.rs` and wants the safety net, OR (c) we are doing a v-patch that is otherwise small and want to bundle the CI hardening with it.
+
+**What we will NOT do as a workaround**:
+
+- **Block CI on the wheel build for all 6 test cells** (3 Pythons x 2 platforms). The wheel-build job runs once per platform with Python 3.13. The matrix-Python angle is the existing `test` job's responsibility - it exercises subprocess fallback paths (`telemetry.py:get_head_commit` falls through to `git_run_safe` when `import presence_ext` fails), not wheel-loading.
+- **Build wheels for Windows.** presence is documented as "install in WSL2" for Windows; wheel-CI does not need to lead the Windows native story.
+- **Run on every push event.** `pull_request` + `push: branches: [main]` is the right scope (mirrors the existing `test` job).
+- **Smoke-test deeply.** The wheel-CI smoke test verifies "the wheel imports and the basic shape of one function works". Full ext behavior is the responsibility of `tests/test_zerotrust_integration.py` and the daemon-fallback paths in the existing `test` job.
+- **Publish the wheel.** The wheel is a build-time artifact for verification only. presence does not distribute wheels via GitHub Releases (per `docs/architecture.md` the ext is built locally with `--build-ext`). Adding wheel publishing is a separate decision that this entry does not make.
+
+**Critical files referenced** (for the implementer's eventual use):
+
+- `.github/workflows/ci.yml` (one new top-level job)
+- `install.sh:413-470` (existing `--build-ext` logic; mirror the cargo + maturin invocation but skip the venv-creation step since CI's `actions/setup-python` already provides the interpreter)
+- `ext/Cargo.toml` and `ext/src/lib.rs` (no changes; just the build target)


### PR DESCRIPTION
## Summary

Two new roadmap entries documenting design decisions that came out of the v0.5.x release cycle. Both stem from the same incident - dependabot PR #17 (April 2026) bumped \`pyo3 0.21 -> 0.24\` with green CI on every existing job, but the wheel build was actually broken (15 compile errors from the missing Bound API migration). Caught locally with \`maturin build\`; the fix shipped as v0.5.3 / PR #29. We want this class of bug caught automatically next time, from two angles.

The entries are deliberately separate because they solve different sub-problems:

| Problem | Caught by | When |
|---|---|---|
| Upstream dep breakage (dependabot PR with API migration that the diff doesn't cover) | **Wheel build in CI** | At PR review time, blocks merge |
| Downstream user state drift (\`git pull\` without \`--build-ext\`, stale wheel relative to current Python plugin) | **Version observability + freshness** | At SessionStart on user machine, surfaces in \`/presence-doctor\` |

Either would have caught PR #17. Together they cover both sides (gate at merge + detector at runtime). One PR ships both because they're co-motivated and both decision-history-only.

### What this PR does NOT do

- **No code changes.** Both entries are deferred design. Implementation lands in future patch / minor releases.
- **No version bump.** \`docs/roadmap.md\` is not in the integrity manifest; no MANIFEST regen.
- **No CHANGELOG entry.** This matches the prior multi-tool framing roadmap PR's posture - roadmap-doc PRs are decision history, not user-visible feature work.

## Entry 1: Version observability and freshness (commit \`c30e218\`)

Four-step design, in increasing scope:

1. **Static version surfaces** (ext-only): \`presence_ext.__version__\` Python attribute via \`m.add(\"__version__\", env!(\"CARGO_PKG_VERSION\"))\` in \`ext/src/lib.rs\`; \`presence-client --version\` flag in \`ext/src/client.rs\`.
2. **Doctor cross-check** (~1 hr, lib-only on top of #1): \`/presence-doctor\` shows plugin Python version vs ext crate version vs expected ext version.
3. **Compatibility bound + SessionStart warn** (lib-only on top of #2): \`_MIN_EXT_VERSION\` constant; SessionStart hooks call \`check_ext_compat()\` and \`warn(\"ext_version_stale\", ...)\` on mismatch. Reuses existing \`warnings_log.warn()\` infrastructure.
4. **Opt-in network freshness check** (new surface): one outbound call to GitHub Releases API with 24h cache. Default OFF in every preset; \`zerotrust\` hard-codes false. Surfaces in \`/presence-doctor\` only - never SessionStart, never blocking.

Defers to v0.6.0 because items #3 and #4 add new public surface (settings keys, SessionStart codepath) which breaks the v0.5.x stabilization-line contract.

## Entry 2: Wheel build in CI (commit \`70d5315\`)

One new job in \`.github/workflows/ci.yml\`: \`wheel-build\` matrix on \`ubuntu-latest\` + \`macos-latest\`, Python 3.13 only. Steps: rust-toolchain stable, install Linux system libs (mirror release.yml), cache cargo registry + \`ext/target\`, install maturin, \`maturin build --release\`, install the wheel, smoke-test \`import presence_ext\` + one function call.

Three things this catches that current CI misses entirely:

1. Bound API breakage from any pyo3 / pyext-feature-gated dep bump.
2. Platform-specific build failures (macOS uses security-framework, Linux uses secret-service - the two cells together cover both \`cfg(target_os = ...)\` branches in \`ext/src/crypto.rs\`).
3. Dynamic-link / ABI mismatches that compile-time misses but \`import presence_ext\` catches.

Cost: ~2-4 minutes per PR (warm cache makes it ~30 seconds). Deferred but not gated on a v-minor; a CI workflow change can ship in any patch release whenever the next pyo3 / pyext-gated dep bump is on the horizon.

## Test plan

- [x] \`grep -E \"^## \" docs/roadmap.md\` lists 8 sections in expected order; the two new entries are #7 (Version observability) and #8 (Wheel build in CI).
- [x] \`lib/integrity.py --verify\` OK (file is not manifest-tracked).