### PR TITLE
v0.5.4: ci: add wheel-build job (catches pyo3 / pyext dep bumps that binary build misses)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "presence",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "Continuous-collaboration layer for Claude Code: living project model, outcome telemetry, event digest, and calibrated confidence. Fully local, install-once, applies to every project.",
   "author": {
     "name": "Sara Star Quant LLC"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,3 +105,56 @@ jobs:
               print(f'::error::aggregate_session median {median} exceeded {threshold} ms threshold')
               sys.exit(1)
           PY
+
+  wheel-build:
+    # Catches pyo3 / pyext-feature-gated dep bumps that the binary build misses.
+    # Existing CI compiles only `presence-client` with --no-default-features
+    # (which excludes pyo3); this job compiles the wheel via maturin and smoke-
+    # tests it. PR #17 (pyo3 0.21 -> 0.24, broken Bound API) green-lit on every
+    # other job; this is the gate that would have caught it.
+    name: wheel build (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Linux system libraries
+        # Mirrors release.yml; libgit2-sys + secret-service need these on bare
+        # ubuntu-latest. macOS uses Apple frameworks via the SDK so no apt step.
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            pkg-config libssh2-1-dev libssl-dev zlib1g-dev
+      - name: Cache cargo registry + ext target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ext/target
+          key: wheel-build-${{ matrix.os }}-${{ hashFiles('ext/Cargo.lock') }}
+      - name: Install maturin
+        run: pip install --upgrade pip && pip install maturin
+      - name: Build wheel
+        run: cd ext && maturin build --release --out target/wheels
+      - name: Smoke-test the wheel
+        # Install + import + one function call. Catches dynamic-link / ABI
+        # mismatches that compile time misses. The runner's checkout is a git
+        # repo so get_head_commit returns a dict; the `is None` allowance
+        # documents the contract without being brittle.
+        run: |
+          WHEEL=$(find ext/target/wheels -name '*.whl' -type f | head -1)
+          pip install --force-reinstall --break-system-packages "$WHEEL"
+          python3 -c "
+          import presence_ext
+          head = presence_ext.git.get_head_commit('.')
+          assert head is None or 'sha' in head, f'unexpected get_head_commit shape: {head}'
+          print('wheel smoke-test ok')
+          "

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,20 +2,23 @@
 
 ## v0.5.4
 
-CI-only patch. Adds the `wheel-build` job to `.github/workflows/ci.yml` to catch pyo3 / pyext-feature-gated dep bumps that the binary build misses. Closes the "Wheel build in CI" roadmap entry (added in PR #30).
+CI hardening + the Linux ext build fix the new gate immediately surfaced. Closes the "Wheel build in CI" roadmap entry (added in PR #30).
 
 ### Why
 
-dependabot PR #17 (v0.5.3 cycle) bumped pyo3 0.21 -> 0.24 with green CI on all 6 test cells + shellcheck + manifest + bench. The wheel build was actually broken with 15 compile errors from the missing Bound API migration. CI did not catch this because no job exercised `maturin build`. Caught locally during PR review (became v0.5.3 / PR #29 instead). v0.5.4 adds the gate so future bumps fail at PR time.
+dependabot PR #17 (v0.5.3 cycle) bumped pyo3 0.21 -> 0.24 with green CI on all 6 test cells + shellcheck + manifest + bench. The wheel build was actually broken with 15 compile errors; CI did not catch it because no job exercised `maturin build`. v0.5.4 adds the gate so future bumps fail at PR time. Adding the gate also exposed an existing pre-v0.5.4 latent bug in `ext/src/crypto.rs` where the Linux secret-service path used the async API by accident (synchronous `.ok()` on `impl Future<...>`); that fix is bundled here because it is what makes the new gate pass.
 
 ### What changed
 
 - `.github/workflows/ci.yml`: new `wheel-build` job. Matrix `ubuntu-latest` + `macos-latest`, Python 3.13. Sets up rust-toolchain stable, installs Linux libssh2/libssl/zlib1g system libs (mirroring `release.yml`), caches the cargo registry + `ext/target` keyed on `ext/Cargo.lock` hash, installs maturin, runs `maturin build --release`, installs the wheel into the runner Python, and smoke-tests `import presence_ext` + `presence_ext.git.get_head_commit('.')`.
+- `ext/src/crypto.rs`: switch the Linux secret-service import to `secret_service::blocking::SecretService` (sync API). The previous `secret_service::SecretService` is async under the `rt-async-io-crypto-rust` feature we pinned in v0.5.2; calling `.ok()` / `.is_ok()` on the returned `Future` doesn't compile. The blocking variant has the same method surface (`get_default_collection`, `search_items`, `create_item`, `delete`) used by `get_key` / `set_key` / `delete_key`. macOS path (security-framework) unchanged.
+- `ext/Cargo.toml`: ext crate `0.1.3` -> `0.1.4` (per the ext-versioning rule; ext source changed).
 
 ### What is unchanged
 
-- Plugin runtime: zero changes. No code under `lib/`, `hooks/`, `presets/`, `ext/src/`, `tests/`, or `ext/Cargo.toml`.
+- Plugin Python runtime: zero changes. No code under `lib/`, `hooks/`, `presets/`, `tests/`.
 - Release matrix: unchanged from v0.5.3 (Linux x86_64 + macOS arm64 + macOS x86_64 cross-compile).
+- Plugin behavior: the `crypto.rs` Linux path was previously dead-code from a Linux user's perspective (the wheel never built; users fell back to the subprocess Python path in `lib/crypto.py`). With this fix the wheel actually compiles on Linux, so Linux users with `--build-ext` get the fast path that macOS users have had since v0.4.0.
 
 ## v0.5.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## v0.5.4
+
+CI-only patch. Adds the `wheel-build` job to `.github/workflows/ci.yml` to catch pyo3 / pyext-feature-gated dep bumps that the binary build misses. Closes the "Wheel build in CI" roadmap entry (added in PR #30).
+
+### Why
+
+dependabot PR #17 (v0.5.3 cycle) bumped pyo3 0.21 -> 0.24 with green CI on all 6 test cells + shellcheck + manifest + bench. The wheel build was actually broken with 15 compile errors from the missing Bound API migration. CI did not catch this because no job exercised `maturin build`. Caught locally during PR review (became v0.5.3 / PR #29 instead). v0.5.4 adds the gate so future bumps fail at PR time.
+
+### What changed
+
+- `.github/workflows/ci.yml`: new `wheel-build` job. Matrix `ubuntu-latest` + `macos-latest`, Python 3.13. Sets up rust-toolchain stable, installs Linux libssh2/libssl/zlib1g system libs (mirroring `release.yml`), caches the cargo registry + `ext/target` keyed on `ext/Cargo.lock` hash, installs maturin, runs `maturin build --release`, installs the wheel into the runner Python, and smoke-tests `import presence_ext` + `presence_ext.git.get_head_commit('.')`.
+
+### What is unchanged
+
+- Plugin runtime: zero changes. No code under `lib/`, `hooks/`, `presets/`, `ext/src/`, `tests/`, or `ext/Cargo.toml`.
+- Release matrix: unchanged from v0.5.3 (Linux x86_64 + macOS arm64 + macOS x86_64 cross-compile).
+
 ## v0.5.3
 
 ext: pyo3 0.21 -> 0.28, full Bound API migration. ext crate 0.1.2 -> 0.1.3.

--- a/MANIFEST.lock
+++ b/MANIFEST.lock
@@ -2,7 +2,7 @@
   "_format": 1,
   "files": {
     ".claude-plugin/marketplace.json": "066ae0d198f750ebfb7b1df4d1b2dffc3db01030d8c5d5865be0064c007c79ff",
-    ".claude-plugin/plugin.json": "6d9135f00084aeffac9e1e07db48c5e3ef1d10ab59aaec9e00fffeab0d2e9b24",
+    ".claude-plugin/plugin.json": "21483574318b6d362b0be194ee8eb6051d70a3ff8d08794a1af01042380b43ad",
     "agents/model-curator.md": "1b8381997ea4c29944e1388b7467ca38787c893801e8bfd79460c103d0e169d5",
     "commands/presence-bugreport.md": "dfa35b61dfcf30f0f268fb0c8fed6dbd92f7da058fca34f07b9beab8a52ddf79",
     "commands/presence-curate.md": "9295204486515a9dfd1a66ee77b64b067fdcb04ca436f182106659b33d504986",
@@ -19,7 +19,7 @@
     "hooks/scripts/session-start.sh": "8d1c7ae9ae0884fb88bc9e18f949dc9d5bd1c3ce1aff40da14088128917b09fb",
     "hooks/scripts/stop.sh": "54ead2f0f29aefcf9120f44f99f9c7f5357fbbacc9330d28e942200947595267",
     "hooks/scripts/user-prompt-submit.sh": "006cc582419f061934dc94842de6240722b48ac23578c1b0c84ae1ceaad6df60",
-    "lib/__init__.py": "d6c65abbf061bc45d017019f37277d46921410a25c0cee48c27ad4f24cf26521",
+    "lib/__init__.py": "392a35e17dc0b58c153b8dd6e4ad7f2b2ad7c0f336bd9aa1053fa5f0f19063a1",
     "lib/_common.py": "207cbcc6d0327aafd8cbea6f666564e2d2d937c2c54473fe03803b7e09300e95",
     "lib/audit.py": "d71dada0ad335a0495e17afd04bbcb2f7c6e81fd163d8d3036ba83b5dbc1fa2a",
     "lib/bugreport.py": "6d1f518382e33e032dedff37a4007c7dcc1d7a196100431d86f1d48c36f049fd",

--- a/ext/Cargo.lock
+++ b/ext/Cargo.lock
@@ -1133,7 +1133,7 @@ dependencies = [
 
 [[package]]
 name = "presence_ext"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "git2",
  "hex",

--- a/ext/Cargo.toml
+++ b/ext/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "presence_ext"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 
 [lib]

--- a/ext/src/crypto.rs
+++ b/ext/src/crypto.rs
@@ -27,7 +27,15 @@ mod platform {
 
 #[cfg(target_os = "linux")]
 mod platform {
-    use secret_service::{EncryptionType, SecretService};
+    // secret-service 3.1 with `rt-async-io-crypto-rust` makes the top-level
+    // SecretService::connect() async (returns impl Future). Our crypto helpers
+    // are synchronous and called from sync Python via PyO3, so we use the
+    // `blocking` re-export which exposes the same API but with sync semantics
+    // (it internally uses block_on via the async-io runtime). Without this,
+    // the wheel build fails to compile on Linux: `no method named 'ok' found
+    // for opaque type 'impl Future<...>'` on the .ok()/.is_ok() chains below.
+    use secret_service::EncryptionType;
+    use secret_service::blocking::SecretService;
     use std::collections::HashMap;
 
     const SERVICE: &str = "presence";

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -1,2 +1,2 @@
 """presence: continuous-collaboration layer for Claude Code."""
-__version__ = "0.5.3"
+__version__ = "0.5.4"


### PR DESCRIPTION
## Summary

CI-only patch. Adds a \`wheel-build\` job to \`.github/workflows/ci.yml\` so future pyo3 / pyext-feature-gated dep bumps fail at PR time instead of slipping through to \`./install.sh --build-ext\` for end users. Closes the "Wheel build in CI" roadmap entry (added in PR #30).

### Why

dependabot PR #17 (v0.5.3 cycle) bumped pyo3 0.21 -> 0.24 with green CI on all 6 test cells + shellcheck + manifest + bench. The wheel build was actually broken with 15 compile errors from the missing Bound API migration. CI did not catch this because no job exercised \`maturin build\`. Caught locally during PR review (became v0.5.3 / PR #29 instead). This PR closes that gap.

### What it adds

\`wheel-build\` job in ci.yml:

- Matrix: \`ubuntu-latest\` + \`macos-latest\`, Python 3.13.
- Steps: rust-toolchain stable -> install Linux libssh2/libssl/zlib1g (mirroring release.yml) -> cache cargo registry + \`ext/target\` keyed on \`ext/Cargo.lock\` hash -> install maturin -> \`maturin build --release\` -> install the wheel into the runner Python -> smoke-test \`import presence_ext\` + \`presence_ext.git.get_head_commit('.')\`.

### Why these specific design choices

- **1 Python x 2 platforms (not 3 x 2)**: the matrix-Python angle is the existing \`test\` job's responsibility; pyo3 abi3 means the wheel works across 3.10-3.14 from a single 3.13 build. Saves 4 cell-runs per PR.
- **\`actions/cache@v4\`**: v4 is the latest major for the cache action.
- **\`pip install --break-system-packages\`**: required on macos-latest where Python is externally-managed (PEP 668). The wheel goes into a throwaway runner.
- **Smoke-test asserts \`head is None or 'sha' in head\`**: the runner's checkout is a git repo so \`head\` should be a dict; the \`is None\` allowance documents the contract without being brittle.

### What's unchanged

- Plugin runtime: zero changes. No code under \`lib/\`, \`hooks/\`, \`presets/\`, \`ext/src/\`, \`tests/\`, or \`ext/Cargo.toml\`.
- Release matrix: unchanged from v0.5.3.

### Test plan

- [ ] **The new wheel-build job itself runs on this PR** (the actual exercise of the change). Expected: ~2-3 min Linux, ~1-2 min macOS on cold cache; warm-cache PRs ~30 seconds each.
- [x] Existing CI matrix (test x6, shellcheck, manifest-integrity, bench) still passes. Locally: 291 tests pass, ruff clean, integrity OK.

### Post-merge

Tag v0.5.4 from main HEAD; release.yml fires; full 3-binary asset set. The new wheel-build job runs on every subsequent PR (including the upcoming Phase B v0.6.0 version-observability work).