### PR TITLE
register plugin in enabledPlugins so commands load

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "presence",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Continuous-collaboration layer for Claude Code: living project model, outcome telemetry, event digest, and calibrated confidence. Fully local, install-once, applies to every project.",
   "author": {
     "name": "Sara Star Quant LLC"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.6.1
+
+Installer registers plugin in enabledPlugins so commands load.
+
+`install.sh` created the symlink and registered hooks, but never added `"presence": true` to `enabledPlugins` in `~/.claude/settings.json`. Without that entry, Claude Code loaded the hooks but ignored the plugin's commands, skills, and agents — `/presence-status` and friends returned "Unknown command."
+
+- `install.sh`: `register_plugin` adds the entry during install; `unregister_plugin` removes it during uninstall. Both are idempotent and use python3 for safe JSON manipulation.
+- `install.sh --verify`: new `settings_registered` check (check #3) reports whether the entry is present.
+
 ## v0.6.0
 
 Version observability and freshness. Closes the "Version observability and freshness" roadmap entry as four coordinated surfaces: ext static surfaces, doctor cross-check, SessionStart stale-ext warn, and an opt-in network freshness check against GitHub releases.

--- a/MANIFEST.lock
+++ b/MANIFEST.lock
@@ -2,7 +2,7 @@
   "_format": 1,
   "files": {
     ".claude-plugin/marketplace.json": "066ae0d198f750ebfb7b1df4d1b2dffc3db01030d8c5d5865be0064c007c79ff",
-    ".claude-plugin/plugin.json": "fe28a41c1855cd1326d4ef0fe0458ce3c4fe768fcee6b18812dd434c185364d4",
+    ".claude-plugin/plugin.json": "1fe3ffaed0230982c4752d423d7f905144ce593cf7b32cb1eb043568487a910b",
     "agents/model-curator.md": "1b8381997ea4c29944e1388b7467ca38787c893801e8bfd79460c103d0e169d5",
     "commands/presence-bugreport.md": "dfa35b61dfcf30f0f268fb0c8fed6dbd92f7da058fca34f07b9beab8a52ddf79",
     "commands/presence-curate.md": "9295204486515a9dfd1a66ee77b64b067fdcb04ca436f182106659b33d504986",

--- a/install.sh
+++ b/install.sh
@@ -29,10 +29,58 @@ STATE_DIR="${PRESENCE_STATE:-$CLAUDE_HOME/presence}"
 BOOTSTRAP=0
 VERIFY_JSON=0
 
+SETTINGS_FILE="$CLAUDE_HOME/settings.json"
+PLUGIN_KEY="presence"
+
 die()  { printf '\033[31merror:\033[0m %s\n' "$*" >&2; exit 1; }
 warn() { printf '\033[33mwarn :\033[0m %s\n' "$*" >&2; }
 info() { printf '\033[36minfo :\033[0m %s\n' "$*"; }
 ok()   { printf '\033[32mok   :\033[0m %s\n' "$*"; }
+
+register_plugin() {
+  local py_bin
+  py_bin="$(command -v python3 2>/dev/null || true)"
+  if [ -z "$py_bin" ]; then
+    warn "python3 not available; cannot register plugin in settings.json (commands like /presence-status won't load until fixed)"
+    return 0
+  fi
+  if "$py_bin" -c '
+import json, pathlib, sys
+path = pathlib.Path(sys.argv[1])
+key  = sys.argv[2]
+data = json.loads(path.read_text()) if path.exists() else {}
+ep   = data.setdefault("enabledPlugins", {})
+if ep.get(key) is True:
+    sys.exit(0)
+ep[key] = True
+path.write_text(json.dumps(data, indent=2) + "\n")
+' "$SETTINGS_FILE" "$PLUGIN_KEY" 2>/dev/null; then
+    ok "plugin registered in settings.json"
+  else
+    warn "could not update $SETTINGS_FILE; you may need to enable the plugin manually"
+  fi
+}
+
+unregister_plugin() {
+  local py_bin
+  py_bin="$(command -v python3 2>/dev/null || true)"
+  [ -z "$py_bin" ] && return 0
+  if "$py_bin" -c '
+import json, pathlib, sys
+path = pathlib.Path(sys.argv[1])
+key  = sys.argv[2]
+if not path.exists():
+    sys.exit(0)
+data = json.loads(path.read_text())
+ep   = data.get("enabledPlugins", {})
+if key not in ep:
+    sys.exit(0)
+del ep[key]
+path.write_text(json.dumps(data, indent=2) + "\n")
+' "$SETTINGS_FILE" "$PLUGIN_KEY" 2>/dev/null; then
+    ok "plugin unregistered from settings.json"
+  fi
+}
 
 check_python() {
   # Returns 0 iff a usable python3 (>= 3.12) is on PATH. Side effect: prints
@@ -174,7 +222,26 @@ verify() {
     fi
   fi
 
-  # 3. Hook scripts executable (all 6).
+  # 3. Plugin registered in settings.json (commands/skills/agents won't load without this).
+  if [ -f "$SETTINGS_FILE" ] && [ -n "$py_bin" ]; then
+    local is_registered
+    is_registered=$("$py_bin" -c '
+import json, pathlib, sys
+data = json.loads(pathlib.Path(sys.argv[1]).read_text())
+print("yes" if data.get("enabledPlugins", {}).get(sys.argv[2]) is True else "no")
+' "$SETTINGS_FILE" "$PLUGIN_KEY" 2>/dev/null || echo "error")
+    case "$is_registered" in
+      yes) _record "settings_registered" "true" "$PLUGIN_KEY enabled in $SETTINGS_FILE" ;;
+      no)  _record "settings_registered" "false" "$PLUGIN_KEY not in enabledPlugins (commands won't load; rerun install)" ;;
+      *)   _record "settings_registered" "false" "could not read $SETTINGS_FILE" ;;
+    esac
+  elif [ ! -f "$SETTINGS_FILE" ]; then
+    _record "settings_registered" "false" "$SETTINGS_FILE does not exist (rerun install)"
+  else
+    _record "settings_registered" "false" "no usable python to check settings"
+  fi
+
+  # 4. Hook scripts executable (all 6).
   local hook_missing=""
   for h in session-start.sh user-prompt-submit.sh pre-tool-bash.sh post-tool-bash.sh post-tool-edit.sh stop.sh; do
     if [ ! -x "$SCRIPT_DIR/hooks/scripts/$h" ]; then
@@ -187,7 +254,7 @@ verify() {
     _record "hook_scripts_executable" "false" "not executable:$hook_missing"
   fi
 
-  # 4. State perms (portable across BSD/GNU stat via python).
+  # 5. State perms (portable across BSD/GNU stat via python).
   if [ -d "$STATE_DIR" ]; then
     if [ -n "$py_bin" ]; then
       local mode
@@ -204,7 +271,7 @@ verify() {
     _record "state_perms" "false" "$STATE_DIR does not exist"
   fi
 
-  # 5. MANIFEST.lock present + integrity verifies.
+  # 6. MANIFEST.lock present + integrity verifies.
   if [ ! -f "$SCRIPT_DIR/MANIFEST.lock" ]; then
     _record "manifest_integrity" "false" "MANIFEST.lock missing (run install)"
   elif [ -z "$py_bin" ]; then
@@ -215,7 +282,7 @@ verify() {
     _record "manifest_integrity" "false" "MANIFEST.lock present but integrity --verify failed"
   fi
 
-  # 6. Synthetic fire of all 6 hooks. Each must exit 0; stdout (if any) must
+  # 7. Synthetic fire of all 6 hooks. Each must exit 0; stdout (if any) must
   # be valid JSON. Catches import regressions in any hook entry point.
   local hooks_failed=""
   for entry in \
@@ -248,7 +315,7 @@ verify() {
     _record "hook_synthetic_fire" "false" "$hooks_failed"
   fi
 
-  # 7. Doctor pass (optional, informative).
+  # 8. Doctor pass (optional, informative).
   local doctor_json_file=""
   if [ -n "$py_bin" ]; then
     doctor_json_file=$(mktemp)
@@ -390,6 +457,7 @@ uninstall() {
   for arg in "$@"; do
     [ "$arg" = "--purge" ] && purge=1
   done
+  unregister_plugin
   if [ -L "$PLUGIN_LINK" ]; then
     rm -f "$PLUGIN_LINK"
     ok "removed plugin symlink: $PLUGIN_LINK"
@@ -541,6 +609,8 @@ install() {
     ln -s "$SCRIPT_DIR" "$PLUGIN_LINK"
     ok "plugin linked: $PLUGIN_LINK -> $SCRIPT_DIR"
   fi
+
+  register_plugin
 
   # Create state directory with restrictive perms
   mkdir -p "$STATE_DIR"


### PR DESCRIPTION
## Summary

- `install.sh`: `register_plugin`/`unregister_plugin` add/remove `"presence": true` in `~/.claude/settings.json` enabledPlugins. Idempotent, uses python3 for safe JSON manipulation.
- `install.sh --verify`: new `settings_registered` check (#3) reports whether the entry is present.
- Version bump 0.6.0 → 0.6.1.