### PR TITLE
note the 80% statement-coverage target in the roadmap

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -54,6 +54,18 @@ The bar to add an item here is: someone asked, the maintainer thought about it, 
 
 **Why deferred**: niche use case (only repo maintainers + plugin authors). Not worth the install.sh complexity until someone other than the maintainer asks for it.
 
+## Raise statement coverage to 80% (OpenSSF Silver target)
+
+**Tracking**: #39
+
+**Status**: CI gates coverage at 65% as of v0.6.2; 80% waits on hook tests.
+
+**Today**: the `coverage` job measures ~67%. It captures the hooks and daemon (which run as subprocesses) via `COVERAGE_PROCESS_START` + `coverage combine`; a plain in-process `--cov` reads 59% because it misses them. Most of the gap to 80% sits in the action hooks (`lib/hook_stop.py`, `lib/hook_post_tool_bash.py`, `lib/hook_pre_tool_bash.py`, `lib/hook_post_tool_edit.py`): `tests/test_hooks_smoke.py` checks only that they run on trivial input, not their branches.
+
+**Proposal**: test each hook with real payloads (transcript parsing, revert detection, redaction, the confidence gate), then step the CI `--fail-under` up to 80.
+
+**Why deferred**: 80% is the Silver `test_statement_coverage80` criterion, and Silver already blocks on the single-maintainer rules (2+ contributors, bus factor >= 2, two-person review). Worth doing regardless, but no rush to hit the exact number while those block the badge.
+
 ## Agent Client Protocol (ACP) for Zed and other ACP-aware tools
 
 **Status**: distinct from MCP; tracked separately for a future minor once a real Zed-side use case shows up.


### PR DESCRIPTION
Adds a roadmap entry for the OpenSSF Silver `test_statement_coverage80` goal, tracked in #39.

CI measures statement coverage at ~67% and gates at a 65% floor (v0.6.2); the gap to 80% is the action hooks, only smoke-tested today. Deferred behind the structural Silver blockers (2+ contributors, bus factor, two-person review).

Docs-only.