### PR TITLE
add the OpenSSF Best Practices passing badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # presence
 
 [![CI](https://github.com/sara-star-quant/presence/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/sara-star-quant/presence/actions/workflows/ci.yml)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13085/badge)](https://www.bestpractices.dev/projects/13085)
 [![Latest release](https://img.shields.io/github/v/release/sara-star-quant/presence?sort=semver&cacheSeconds=60)](https://github.com/sara-star-quant/presence/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12%20%7C%203.13%20%7C%203.14-blue)](.github/workflows/ci.yml)


### PR DESCRIPTION
presence earned the OpenSSF Best Practices **passing** badge (project 13085, 2026-06-03). This adds the live badge to the README badge block, next to CI.

https://www.bestpractices.dev/en/projects/13085

Docs-only.