### PR TITLE
add governance, dependency monitoring, and security/assurance docs for OpenSSF Silver

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# Dependency monitoring for known vulnerabilities and updates (OpenSSF dependency_monitoring).
+# The Python runtime is stdlib-only (one optional dep, cryptography); the dev group and the
+# Rust ext (ext/Cargo.toml) carry the third-party dependencies worth watching.
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "cargo"
+    directory: "/ext"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,62 @@
+CODE OF CONDUCT
+
+Our pledge
+
+We as members, contributors, and maintainers pledge to make participation in our community a harassment free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+Our standards
+
+Examples of behavior that contributes to a positive environment include:
+
+1. Demonstrating empathy and kindness toward other people
+2. Being respectful of differing opinions, viewpoints, and experiences
+3. Giving and gracefully accepting constructive feedback
+4. Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+5. Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+1. The use of sexualized language or imagery, and sexual attention or advances of any kind
+2. Trolling, insulting or derogatory comments, and personal or political attacks
+3. Public or private harassment
+4. Publishing others private information, such as a physical or email address, without their explicit permission
+5. Other conduct which could reasonably be considered inappropriate in a professional setting
+
+Enforcement responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the maintainer (currently Peter Z., GitHub `@pzverkov`) through the contact link on the GitHub profile linked from the repo (`sara-star-quant`). All complaints will be reviewed and investigated promptly and fairly.
+
+If sensitive details are involved, do not include them in a public issue; request a private contact method first. For security-relevant reports, use the channel in [`SECURITY.md`](SECURITY.md) instead.
+
+Enforcement guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+1. Correction
+   Community impact: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+   Consequence: A private, written warning providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+2. Warning
+   Community impact: A violation through a single incident or series of actions.
+   Consequence: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time.
+3. Temporary ban
+   Community impact: A serious violation of community standards, including sustained inappropriate behavior.
+   Consequence: A temporary ban from any sort of interaction or public communication with the community for a specified period of time.
+4. Permanent ban
+   Community impact: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+   Consequence: A permanent ban from any sort of public interaction within the community.
+
+Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant, version 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,13 +59,11 @@ Commit the regenerated `MANIFEST.lock` alongside the source change. CI's `manife
 
 ### Statement coverage
 
-CI's `coverage` job gates statement coverage at 65% (the Silver-badge target is 80%). The hooks and daemon run as subprocesses, so measuring them needs a one-time setup; an in-process `pytest --cov` undercounts. To reproduce the CI number locally:
+CI's `coverage` job gates statement coverage at 67% (the Silver-badge target is 80%, tracked in #39). Measurement is in-process and deterministic; `daemon.py` is omitted (it runs only as a subprocess and is behavior-tested by `tests/test_daemon.py`). To reproduce the CI number locally:
 
 ```bash
-SP=$(.venv/bin/python -c "import sysconfig; print(sysconfig.get_path('purelib'))")
-printf 'import coverage; coverage.process_startup()\n' > "$SP/subcov.pth"
-COVERAGE_PROCESS_START=$PWD/pyproject.toml PYTHONPATH=lib .venv/bin/coverage run -m pytest -q
-.venv/bin/coverage combine && .venv/bin/coverage report
+PYTHONPATH=lib .venv/bin/coverage run -m pytest -q
+.venv/bin/coverage report
 ```
 
 ## Adding a test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,14 @@ Requires pip 25.1 or later. If your pip is older, the equivalent is:
 
 Python 3.12+ is required. CI runs against 3.12, 3.13, and 3.14 on both Linux and macOS.
 
+## Coding standards
+
+- **Python** follows PEP 8, enforced by ruff (configuration in `pyproject.toml [tool.ruff]`); ruff also applies bugbear, pyupgrade, security (flake8-bandit), and other rule sets.
+- **Shell** scripts follow shellcheck's recommendations.
+- **Rust** (the optional `ext/` extension) follows rustfmt formatting and clippy lints.
+
+These run in CI and must pass before merge. Style exceptions are rare and annotated inline at their location (e.g. `# noqa`, `# nosec`).
+
 ## Local checks before opening a PR
 
 All five must be green:
@@ -99,7 +107,7 @@ The `bench/` harness is the source of truth for any "X is faster" claim. Reprodu
 
 ## Code of conduct
 
-Be polite, be specific, assume good faith. Disagreements are welcome; personal attacks are not. The maintainer reserves the right to lock or close threads that get unproductive.
+This project follows the [Contributor Covenant](CODE_OF_CONDUCT.md). In short: be polite, be specific, assume good faith. See [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) for the expected behavior and how to report unacceptable conduct.
 
 ## License
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,30 @@
+# Governance
+
+## Model
+
+presence uses a single-maintainer ("benevolent dictator") model. The maintainer makes the final decisions on scope, design, releases, and dispute resolution. Anyone may propose changes via a pull request or open an issue to discuss direction; the maintainer reviews, requests changes, and decides what merges.
+
+Because the project is FLOSS under the MIT license, anyone may fork at any time if they disagree with the direction.
+
+## Roles and responsibilities
+
+- **Maintainer** (currently Peter Z., GitHub `@pzverkov`):
+  - Triages issues and reviews/merges pull requests.
+  - Owns the release process (version bump, signed tag, GitHub release) - see [CONTRIBUTING.md](CONTRIBUTING.md).
+  - Holds the credentials needed to operate the project: GitHub repository admin, the GPG release signing key, the PyPI account for the `presence-mcp` launcher, and the OpenSSF Best Practices entry.
+  - Sets and enforces the hard constraints in [CONTRIBUTING.md](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md).
+- **Contributors**: anyone who opens an issue or pull request. Contributions must meet the requirements in [CONTRIBUTING.md](CONTRIBUTING.md) (tests for behavior changes, lint, ASCII-only, branch -> PR -> review).
+
+## Decision making
+
+Routine changes: the maintainer reviews and merges. Larger or contentious changes are discussed in a GitHub issue first; the maintainer makes the final call and records the reasoning in the issue or PR thread.
+
+## Continuity and succession
+
+The project is currently single-maintainer (bus factor 1). To keep it recoverable if the maintainer becomes unavailable:
+
+- The repository lives in the `sara-star-quant` GitHub organization, so another organization owner can be added and can administer the repository, issues, and releases.
+- The credentials required to continue the project (GitHub org/repo admin, the GPG release signing key plus its revocation certificate, the PyPI launcher account) are kept by the maintainer in a personal secret store so they can be recovered or transferred.
+- Adding a second maintainer - which raises the bus factor to 2 and enables two-person review - is an explicit near-term goal. Until then, this document records the recovery path.
+
+Because the code is MIT-licensed, the project can also continue via a fork even without an access transfer.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,7 +34,7 @@ The full threat model lives in [`docs/security.md`](docs/security.md) (T1 throug
 
 - Hooks must never make Claude Code observe a presence-induced error (`safe_main` outermost guard).
 - Hooks must never leak private data to stdout (only structured `additionalContext` text; no raw env, no raw file contents, no auth headers).
-- State files must remain readable only by the owning user (`0o700` / `0o600`, verified at every SessionStart).
+- State files must remain readable only by the owning user (`0o700` / `0o600`, set on write and re-tightened on demand via `/presence-doctor --fix`).
 - Logged commands containing secrets must be redacted before write (`lib/redact.py`; aggressive redaction under the `zerotrust` preset).
 - Plugin file integrity must be verifiable on demand (`/presence-doctor` in v0.1; SessionStart fail-closed in v0.2 under `zerotrust`).
 - Under `zerotrust`: state at rest must be AES-GCM encrypted with the data key wrapped in the OS keychain; the audit log must be tamper-evident with a per-line SHA-256 hash chain; `presence-unlock` must gate any settings.json or preset write.
@@ -51,7 +51,7 @@ The following are **not** considered vulnerabilities for the purposes of this po
 
 ## Verifying a release
 
-Release tags are GPG-signed. To verify a tag you have checked out:
+Release tags are GPG-signed from v0.6.2 onward (earlier tags predate the signing setup). To verify a signed tag you have checked out:
 
 1. Import the maintainer's public signing key (GPG key `3D675B9061B2B930`), published on the maintainer's GitHub account at `https://github.com/pzverkov.gpg`.
 2. Run `git tag -v v<X.Y.Z>` and confirm a "Good signature" from that key.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,13 +10,22 @@ Do **not** file a public issue for security-relevant findings. The maintainer wi
 
 If GitHub Security Advisories is not available to you for any reason, contact the maintainer through the GitHub profile linked from the repo (`sara-star-quant`).
 
+## Response process
+
+Once a report arrives:
+
+1. The maintainer acknowledges receipt within 14 days (usually sooner).
+2. The report is triaged: reproduce, assess severity, and confirm whether it is in scope (see below).
+3. A fix is developed privately in the GitHub Security Advisory. Medium and higher severity issues are patched within 60 days of confirmation; critical issues are prioritized.
+4. A patched release is published, the advisory is disclosed, and the reporter is credited unless they request anonymity.
+
 ## Supported versions
 
 Only the most recent minor release of `presence` is actively supported. Patch releases backport security fixes within the same minor line; older minors do not receive backports unless an issue is severe and the upgrade path is blocked.
 
 | Version | Supported |
 |---|---|
-| latest minor (currently 0.3.x) | yes |
+| latest minor (currently 0.6.x) | yes |
 | earlier minor lines | no |
 
 ## Threat model in scope
@@ -39,6 +48,15 @@ The following are **not** considered vulnerabilities for the purposes of this po
 - Side-channel timing attacks on hook execution.
 - The optional `gh pr` outcome check (in `team-oss`+ presets) reaching GitHub's API. This is a documented opt-in network call and is disabled in `zerotrust`.
 - The opt-in `install.sh --bootstrap` flag fetching `https://astral.sh/uv/install.sh`. This is documented as an explicit network call requiring the user's `--bootstrap` flag; the default install path makes no outbound calls.
+
+## Verifying a release
+
+Release tags are GPG-signed. To verify a tag you have checked out:
+
+1. Import the maintainer's public signing key (GPG key `3D675B9061B2B930`), published on the maintainer's GitHub account at `https://github.com/pzverkov.gpg`.
+2. Run `git tag -v v<X.Y.Z>` and confirm a "Good signature" from that key.
+
+The private signing key is held only by the maintainer and is never stored on any distribution server.
 
 ## See also
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -40,9 +40,42 @@
 
 Verified at every SessionStart; corrected automatically if loosened.
 
+## Assurance case
+
+This section is the project's assurance case: the argument that presence's security requirements are met. It ties the threat model above to the trust boundaries, the secure-design principles applied, and the common implementation weaknesses countered.
+
+**Claim.** presence does not weaken the security of a developer's machine or Claude Code session: it never crashes the host, never leaks private data into model context or to the network, keeps its state owner-only, and (under Zero-Trust) encrypts state at rest with a tamper-evident audit log.
+
+**Trust boundaries.**
+
+- Claude Code <-> hooks (stdin/stdout): hook input (cwd, tool input/response, transcript path) is untrusted and validated; output is only structured `additionalContext` / decision JSON (T2); a hook failure is contained and exits 0 (T1).
+- Workspace/repo <-> presence: repo content (commit messages, command strings, paths) is untrusted - redacted before storage (T4, T5), path-resolved and scope-checked (T10), never evaluated or imported (T9).
+- presence state <-> other local users: state is owner-only `0o700`/`0o600`, re-verified each SessionStart (T6); integrity is verifiable and fail-closed under Zero-Trust (T7).
+- presence <-> network: no outbound calls by default; the only calls (opt-in `gh pr` check, opt-in `--bootstrap`) are explicit, documented, HTTPS, and disabled under Zero-Trust (T8).
+- Out of scope (outside the boundary): a hostile Claude Code binary, a compromised local account, side-channel timing.
+
+**Secure-design principles applied.**
+
+- Fail-safe defaults: hooks never break the session (`safe_main`, T1); under Zero-Trust, integrity mismatch fails closed (T7).
+- Least privilege / least exposure: owner-only permissions (T6), zero network by default (T8), no shell execution (T11), no untrusted import/eval (T9).
+- Complete mediation: permissions and integrity are re-checked every SessionStart, not once; every stored command passes through redaction (T4).
+- Economy of mechanism: stdlib-only runtime, local files, no service in the default path.
+- Defense in depth: redaction + permissions + integrity + (Zero-Trust) at-rest encryption and a SHA-256 audit chain.
+
+**Common implementation weaknesses countered.**
+
+- OS command injection (CWE-78): subprocess calls use list args, never `shell=True` (T11).
+- Path traversal / link following (CWE-22/59): `Path.resolve()` plus a Zero-Trust allowlist for transcript paths (T10).
+- Sensitive data exposure (CWE-200/532): no private data to stdout (T2); redaction before any log/telemetry write (T4, T5).
+- Unsafe deserialization / code execution (CWE-502/94): JSON only via the standard library; no `eval`/`exec`; `sys.path` extended only with `lib/` (T9).
+- Uncontrolled resource consumption (CWE-400): tail-read caps and event-queue truncation with a hard emergency cap (T12).
+- Incorrect permissions (CWE-276): owner-only perms enforced and re-verified (T6).
+
+Static analysis (ruff including its security `S` rules, plus bandit) runs on every push and gates merges, providing ongoing evidence that these classes stay countered.
+
 ## Reporting a vulnerability
 
-Use the GitHub security advisory flow at `https://github.com/sara-star-quant/presence/security/advisories/new` (available after the repo is published). Until then, file a private issue or contact the maintainer via the GitHub profile contact link rather than disclosing publicly.
+Use the GitHub security advisory flow at `https://github.com/sara-star-quant/presence/security/advisories/new`. See [`SECURITY.md`](../SECURITY.md) for the full reporting and response process.
 
 ## See also
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -11,7 +11,7 @@
 | T3 | Concurrent Claude sessions race on state files | Atomic writes (write-temp + rename); `fcntl.flock` on JSONL appends. Drain operations hold an exclusive lock. |
 | T4 | Logged shell commands contain secrets (e.g. `git commit -m "TOKEN=..."`) | Every command stored in events/telemetry passes through `redact.py` before being written. Standard preset catches well-known token shapes; Zero-Trust preset is aggressive. |
 | T5 | A malicious git repo's commit messages are stored verbatim | Same: messages pass through redaction before being written to telemetry. |
-| T6 | State directory readable by other users on the machine | `~/.claude/presence/` is created with `0o700`; files written `0o600`. Verified at every SessionStart. |
+| T6 | State directory readable by other users on the machine | `~/.claude/presence/` is created with `0o700`; files written `0o600`. Drift is re-tightened on demand via `/presence-doctor --fix`; automatic SessionStart reverification is tracked in the integrity-hardening issue. |
 | T7 | A tampered plugin executes hooks | `MANIFEST.lock` ships with each release. `/presence-doctor` verifies it on demand in v0.1. SessionStart fail-closed on mismatch shipped in v0.2 (active under any preset with `integrity.fail_closed=true`; default in `zerotrust`). |
 | T8 | Network exfiltration | `presence` makes no outbound network calls in v0.1. Optional `gh pr` check (in `team-oss`) is opt-in and goes directly to GitHub's API; disabled in Zero-Trust. |
 | T9 | Untrusted Python code from the workspace gets imported | We never `eval`, `exec`, or import from outside our own `lib/`. `sys.path` (via `PYTHONPATH` in the bash wrappers) is only ever extended with `lib/`. |
@@ -38,7 +38,7 @@
 - All written state files: `0o600` (owner read/write only)
 - Hook scripts in plugin: `0o755` (anyone can read+execute, only owner writes)
 
-Verified at every SessionStart; corrected automatically if loosened.
+Drift is corrected on demand via `/presence-doctor --fix`; automatic SessionStart reverification is tracked in the integrity-hardening issue.
 
 ## Assurance case
 
@@ -50,7 +50,7 @@ This section is the project's assurance case: the argument that presence's secur
 
 - Claude Code <-> hooks (stdin/stdout): hook input (cwd, tool input/response, transcript path) is untrusted and validated; output is only structured `additionalContext` / decision JSON (T2); a hook failure is contained and exits 0 (T1).
 - Workspace/repo <-> presence: repo content (commit messages, command strings, paths) is untrusted - redacted before storage (T4, T5), path-resolved and scope-checked (T10), never evaluated or imported (T9).
-- presence state <-> other local users: state is owner-only `0o700`/`0o600`, re-verified each SessionStart (T6); integrity is verifiable and fail-closed under Zero-Trust (T7).
+- presence state <-> other local users: state is owner-only `0o700`/`0o600`, set on write and re-tightened on demand via `/presence-doctor --fix` (T6); integrity is verifiable and fail-closed under Zero-Trust (T7).
 - presence <-> network: no outbound calls by default; the only calls (opt-in `gh pr` check, opt-in `--bootstrap`) are explicit, documented, HTTPS, and disabled under Zero-Trust (T8).
 - Out of scope (outside the boundary): a hostile Claude Code binary, a compromised local account, side-channel timing.
 
@@ -58,7 +58,7 @@ This section is the project's assurance case: the argument that presence's secur
 
 - Fail-safe defaults: hooks never break the session (`safe_main`, T1); under Zero-Trust, integrity mismatch fails closed (T7).
 - Least privilege / least exposure: owner-only permissions (T6), zero network by default (T8), no shell execution (T11), no untrusted import/eval (T9).
-- Complete mediation: permissions and integrity are re-checked every SessionStart, not once; every stored command passes through redaction (T4).
+- Complete mediation: the integrity gate runs every SessionStart under Zero-Trust, not once; every stored command passes through redaction (T4); permissions are re-tightened on demand via `/presence-doctor --fix`.
 - Economy of mechanism: stdlib-only runtime, local files, no service in the default path.
 - Defense in depth: redaction + permissions + integrity + (Zero-Trust) at-rest encryption and a SHA-256 audit chain.
 


### PR DESCRIPTION
## Summary

Pre-stages most of the OpenSSF Best Practices **Silver** criteria (passing already achieved, project 13085). Docs + config only - no runtime change, no version bump.

## What changed

- **GOVERNANCE.md** (new): single-maintainer model, roles/responsibilities, and a continuity/succession plan -> `governance`, `roles_responsibilities`, `access_continuity`.
- **.github/dependabot.yml** (new): weekly pip + cargo + github-actions updates -> `dependency_monitoring`.
- **SECURITY.md**: a vulnerability response process (triage -> fix within 60 days -> disclose + credit) and a "Verifying a release" section (key `3D675B9061B2B930` via `github.com/pzverkov.gpg` + `git tag -v`); supported-versions corrected `0.3.x` -> `0.6.x` -> `vulnerability_response_process`, `signed_releases`, `documentation_current`.
- **docs/security.md**: an assurance case (claim, trust boundaries, secure-design principles, CWE-countered weaknesses) framing the existing T1-T12 threat model -> `assurance_case`; fixed a stale "after the repo is published" line.
- **CONTRIBUTING.md**: named the coding standards (PEP 8 via ruff, shellcheck, rustfmt/clippy) -> `coding_standards`; replaced the inline CoC text with a pointer to `CODE_OF_CONDUCT.md`.

## Verified

- Assurance-case claims checked against the actual code: no `shell=True`, no `eval`/`exec` in `lib/`, redaction runs before any telemetry write.
- The GPG signing key is published at `https://github.com/pzverkov.gpg`, so the release-verification instructions resolve.

## Follow-ups for the full Silver level

- Add `CODE_OF_CONDUCT.md` (Contributor Covenant) to this branch - GOVERNANCE.md and CONTRIBUTING.md already link it -> `code_of_conduct`.
- #39: statement coverage 69% -> 80% -> `test_statement_coverage80`.

`dco` / `bus_factor` / `crypto_algorithm_agility` are justified SHOULDs. Full analysis kept in the out-of-repo Silver worksheet.
