### PR TITLE
refuse to publish a release from an unsigned tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,19 @@ jobs:
         with:
           fetch-depth: 0   # need full history so the tag commit is reachable
 
+      - name: Verify the release tag is GPG-signed by the maintainer
+        # Only the maintainer's public key is imported, so a good signature here
+        # necessarily comes from that key. Refuse to publish an unsigned tag.
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          curl -fsSL https://github.com/pzverkov.gpg | gpg --import 2>/dev/null
+          if ! git verify-tag "$TAG_NAME"; then
+            echo "::error::tag $TAG_NAME is not signed by the maintainer key; refusing to publish"
+            exit 1
+          fi
+          echo "tag $TAG_NAME carries a good signature from the maintainer key"
+
       - uses: actions/setup-python@v6
         with:
           python-version: "3.13"


### PR DESCRIPTION
## What

Add a release-job step that imports the maintainer GPG key and runs `git verify-tag`, failing the release when the pushed tag carries no good signature.

## Why

v0.5.3 through v0.6.1 shipped as unsigned tags; only v0.6.2 carries a signature. This guard stops an unsigned release from publishing going forward. The step imports only the maintainer key, so a good signature proves maintainer authorship.
