### PR TITLE
update deps versions to latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
@@ -31,7 +31,7 @@ jobs:
     name: shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Run shellcheck
         run: |
           shellcheck hooks/scripts/*.sh
@@ -41,7 +41,7 @@ jobs:
     name: ascii check (unicode)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Reject non-ASCII outside the intentional unicode test fixtures
         # Enforces CONTRIBUTING hard constraints #2 (ASCII-only) and #3 (no
         # em-dashes). git grep -P exits 0 when it finds a match, so a match
@@ -57,7 +57,7 @@ jobs:
     name: ruff (python lint)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
@@ -70,7 +70,7 @@ jobs:
     name: bandit (python security scan)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
@@ -83,7 +83,7 @@ jobs:
     name: coverage (statement)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
@@ -101,7 +101,7 @@ jobs:
     name: regenerate MANIFEST.lock
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
@@ -123,7 +123,7 @@ jobs:
     # CI Linux is typically 1.5-2x slower. Bumping the thresholds is a
     # deliberate, reviewable change.
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
@@ -179,7 +179,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
@@ -193,7 +193,7 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
             pkg-config libssh2-1-dev libssl-dev zlib1g-dev
       - name: Cache cargo registry + ext target
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
             artifact: presence-client-macos-arm64
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Skip if ext/ missing
         id: check_ext
         run: |
@@ -89,10 +89,8 @@ jobs:
           chmod +x "/tmp/release-assets/$ARTIFACT_NAME"
           ls -la /tmp/release-assets/
       - name: Upload artifact
-        # v6 runs on Node 24; v4 was deprecated by GitHub Actions (Node 20
-        # removal scheduled for September 2026, default flip June 2026).
         if: steps.check_ext.outputs.have_ext == 'true'
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact }}
           path: /tmp/release-assets/${{ matrix.artifact }}
@@ -104,7 +102,7 @@ jobs:
     if: always()   # publish even if some Rust builds fail; release notes are independent
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0   # need full history so the tag commit is reachable
 
@@ -197,8 +195,10 @@ jobs:
           fi
 
       - name: Download Rust build artifacts (best-effort)
-        # v6 runs on Node 24; matches the upload-artifact bump above.
-        uses: actions/download-artifact@v6
+        # download-artifact v8 reads artifacts uploaded by upload-artifact v7
+        # (shared v4+ backend). No name filter, so it pulls every matrix
+        # artifact into its own subdir under path.
+        uses: actions/download-artifact@v8
         with:
           path: /tmp/release-assets
         continue-on-error: true   # release notes still publish even if Rust builds failed


### PR DESCRIPTION
GitHub Actions to latest majors: checkout v6, cache v5, upload-artifact v7, download-artifact v8.