### PR TITLE
release v0.7.1: bound the audit-log claim and cover under-tested paths

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "presence",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Continuous-collaboration layer for Claude Code: living project model, outcome telemetry, event digest, and calibrated confidence. Fully local, install-once, applies to every project.",
   "author": {
     "name": "Sara Star Quant LLC"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v0.7.1
+
+Scope the audit-log claim to in-place edits; add test coverage.
+
+A security review of the Zero-Trust surfaces found the audit log's "tamper-evident" description claimed more than a keyless, public-genesis SHA-256 hash chain delivers. The wording now matches the implementation, and three previously under-tested user-facing paths gain coverage. No runtime behavior change.
+
+- `docs/security.md`: the Zero-Trust audit log is now described as tamper-evident against in-place line edits, not end-truncation or a full rewrite. Added notes that macOS key creation exposes the key via process arguments (Linux uses stdin) and that the commit/push confidence gate is advisory, not an access control.
+- Tests cover `async_scan_for_revert`, the redact profile CLI (`--list-profiles` / `--show-profile` / `--test-profile`), and the Zero-Trust storage round-trip (`append_jsonl` encrypts on disk, `read_jsonl` decrypts back). Telemetry coverage 57->78%, redact 66->90%.
+
 ## v0.7.0
 
 Relicense to Apache-2.0.

--- a/MANIFEST.lock
+++ b/MANIFEST.lock
@@ -2,7 +2,7 @@
   "_format": 1,
   "files": {
     ".claude-plugin/marketplace.json": "066ae0d198f750ebfb7b1df4d1b2dffc3db01030d8c5d5865be0064c007c79ff",
-    ".claude-plugin/plugin.json": "5ab973f86871059a916ccc25fef0f88242fcbc142388dece9fc6fcb3a6ed502b",
+    ".claude-plugin/plugin.json": "78614bc3778f5de82ff1de55da7f13ce09f732ba388c37c4cb2f9319b9c30e89",
     "agents/model-curator.md": "1b8381997ea4c29944e1388b7467ca38787c893801e8bfd79460c103d0e169d5",
     "commands/presence-bugreport.md": "dfa35b61dfcf30f0f268fb0c8fed6dbd92f7da058fca34f07b9beab8a52ddf79",
     "commands/presence-curate.md": "9295204486515a9dfd1a66ee77b64b067fdcb04ca436f182106659b33d504986",

--- a/docs/security.md
+++ b/docs/security.md
@@ -22,8 +22,11 @@
 ## What `presence` is **not** trying to defend against
 
 - A compromised Claude Code binary itself. That is outside the trust boundary; if Claude Code is hostile, hooks are not your problem.
-- A compromised local user account. Once an attacker has shell as you, they have your `~/.claude/` regardless of presence.
+- A compromised local user account. Once an attacker has shell as you, they have your `~/.claude/` regardless of presence. In particular the Zero-Trust audit log is tamper-evident against in-place edits of individual lines (the SHA-256 hash chain detects a modified line or a broken link), but its genesis hash is a public constant and the chain carries no secret key, so deleting lines from the end or rewriting the whole file with a fresh valid chain is not detectable. Use it to catch accidental or process-level corruption, not to bind the account owner.
+- A local attacker observing process arguments. On macOS, creating or rotating the keychain data key shells out to `security add-generic-password -w <hex>`, so the key is briefly visible in `ps` for the lifetime of that one subprocess (`security` has no stdin path for the value). The Linux `secret-tool` path passes the key over stdin and does not.
 - Side-channel timing attacks on hook execution.
+
+The PreToolUse commit/push confidence gate is an advisory nudge, not an access control: it is trivially bypassable (rename the command, split it, run git directly) and is meant to prompt verification, not to enforce it.
 
 ## Privacy posture
 
@@ -44,7 +47,7 @@ Re-tightened automatically at every SessionStart, and on demand via `/presence-d
 
 This section is the project's assurance case: the argument that presence's security requirements are met. It ties the threat model above to the trust boundaries, the secure-design principles applied, and the common implementation weaknesses countered.
 
-**Claim.** presence does not weaken the security of a developer's machine or Claude Code session: it never crashes the host, never leaks private data into model context or to the network, keeps its state owner-only, and (under Zero-Trust) encrypts state at rest with a tamper-evident audit log.
+**Claim.** presence does not weaken the security of a developer's machine or Claude Code session: it never crashes the host, never leaks private data into model context or to the network, keeps its state owner-only, and (under Zero-Trust) encrypts state at rest with an audit log that is tamper-evident against in-place edits (see the scope note above for what the chain does and does not bind).
 
 **Trust boundaries.**
 

--- a/tests/test_coverage_climb.py
+++ b/tests/test_coverage_climb.py
@@ -147,6 +147,43 @@ def test_scan_for_revert_finds_revert(isolated_state, fake_repo):
     assert any(f["tracked"] == sha for f in findings)
 
 
+def test_async_scan_for_revert_finds_revert(isolated_state, fake_repo):
+    """The async revert path must find the same revert the sync path does."""
+    import asyncio
+    import subprocess
+
+    t = _reload_telemetry()
+    (fake_repo / "f.txt").write_text("x")
+    subprocess.run(["git", "add", "f.txt"], cwd=fake_repo, check=True)
+    subprocess.run(["git", "commit", "-m", "feature", "-q"], cwd=fake_repo, check=True)
+    sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=fake_repo, capture_output=True, text=True, check=True
+    ).stdout.strip()
+    t.record_commit_claim(str(fake_repo), sha, "feature")
+    subprocess.run(
+        ["git", "commit", "--allow-empty", "-m", f"Revert {sha[:7]} bad", "-q"],
+        cwd=fake_repo, check=True,
+    )
+    findings = asyncio.run(t.async_scan_for_revert(str(fake_repo), 1))
+    assert any(f["tracked"] == sha for f in findings)
+
+
+def test_async_scan_for_revert_empty_without_since(isolated_state, fake_repo):
+    """since_ts=0 short-circuits to [] without touching git."""
+    import asyncio
+
+    t = _reload_telemetry()
+    assert asyncio.run(t.async_scan_for_revert(str(fake_repo), 0)) == []
+
+
+def test_async_scan_for_revert_empty_without_tracked_claims(isolated_state, fake_repo):
+    """No recorded commit claims -> nothing to match reverts against."""
+    import asyncio
+
+    t = _reload_telemetry()
+    assert asyncio.run(t.async_scan_for_revert(str(fake_repo), 1)) == []
+
+
 # --------------------------------------------------------------------------
 # crypto.py key management (backend mocked; no real keychain touched)
 # --------------------------------------------------------------------------
@@ -242,3 +279,62 @@ def test_integrity_cli_write_verify_audit(tmp_path, monkeypatch, capsys):
     # Audit-verify with no audit log present -> exits 0 (nothing to verify).
     monkeypatch.setattr(sys, "argv", ["integrity.py", "--audit-verify"])
     assert integrity._cli() == 0
+
+
+# --------------------------------------------------------------------------
+# Zero-Trust storage round-trip: append_jsonl encrypts on disk under a preset
+# that requests encryption, and read_jsonl transparently decrypts it back.
+# Keychain is mocked; no real `security`/`secret-tool` is touched.
+# --------------------------------------------------------------------------
+
+def test_encrypted_storage_round_trip(isolated_state, monkeypatch):
+    import _common
+    import crypto
+
+    importlib.reload(crypto)
+    importlib.reload(_common)
+
+    key = b"\x07" * crypto.KEY_BYTES
+    # Preset wants events encrypted; provide a deterministic key without a keychain.
+    monkeypatch.setattr(_common, "settings", lambda strict=False: {"events": {"encrypted": True}})
+    monkeypatch.setattr(crypto, "is_available", lambda: True)
+    monkeypatch.setattr(crypto, "get_or_create_key", lambda: key)
+    monkeypatch.setattr(crypto, "_backend_ops", lambda: (lambda: key, lambda k: True, lambda: True))
+    # Reset the per-process caches so the monkeypatched state takes effect.
+    _common._WRITE_STATE_CACHE = None
+    _common._READ_KEY_CACHE = _common._UNSET
+
+    path = isolated_state / "events.jsonl"
+    record = {"kind": "test", "secret": "AKIAIOSFODNN7EXAMPLE", "n": 1}
+    _common.append_jsonl(path, record)
+
+    # On-disk line must be ciphertext, not the plaintext record.
+    raw = path.read_text().strip()
+    assert crypto.is_encrypted_line(raw)
+    assert "AKIAIOSFODNN7EXAMPLE" not in raw
+
+    # read_jsonl transparently decrypts back to the original object.
+    rows = _common.read_jsonl(path)
+    assert rows == [record]
+
+
+def test_encrypted_read_skips_unrecoverable_line(isolated_state, monkeypatch):
+    """An encrypted-looking line with no available key is skipped, not crashed on."""
+    import _common
+    import crypto
+
+    importlib.reload(crypto)
+    importlib.reload(_common)
+
+    # Write one genuinely-encrypted line with a key, then make the key unavailable.
+    key = b"\x09" * crypto.KEY_BYTES
+    enc = crypto.encrypt_line(b'{"kind":"x"}', key)
+    path = isolated_state / "events.jsonl"
+    path.write_text(enc + "\n")
+
+    monkeypatch.setattr(_common, "settings", lambda strict=False: {})
+    monkeypatch.setattr(crypto, "_backend_ops", lambda: (lambda: None, lambda k: True, lambda: True))
+    _common._WRITE_STATE_CACHE = None
+    _common._READ_KEY_CACHE = _common._UNSET
+
+    assert _common.read_jsonl(path) == []

--- a/tests/test_redact_profiles.py
+++ b/tests/test_redact_profiles.py
@@ -355,3 +355,66 @@ def test_shipped_profiles_load_clean(name):
     for pp in r.patterns:
         assert pp.kind
         assert isinstance(pp.pattern, re.Pattern)
+
+
+# ---------- CLI surface (python lib/redact.py ...) ----------
+
+def test_cli_list_profiles_lists_builtins(capsys):
+    import redact
+
+    assert redact._cli(["--list-profiles"]) == 0
+    out = capsys.readouterr().out
+    for name in ("pci-dss", "pii-eu", "pii-us"):
+        assert name in out
+
+
+def test_cli_show_profile_ok(capsys):
+    import redact
+
+    assert redact._cli(["--show-profile", "pci-dss"]) == 0
+    out = capsys.readouterr().out
+    assert "patterns" in out and "schema_version" in out
+
+
+def test_cli_show_profile_not_found_returns_2(capsys):
+    import redact
+
+    assert redact._cli(["--show-profile", "does-not-exist"]) == 2
+    assert "not found" in capsys.readouterr().err
+
+
+def test_cli_test_profile_stdin_redacts(monkeypatch, capsys):
+    import io
+
+    import redact
+
+    # A Luhn-valid PAN must be redacted by the pci-dss profile.
+    monkeypatch.setattr("sys.stdin", io.StringIO("card 4111111111111111 here"))
+    assert redact._cli(["--test-profile", "pci-dss", "--stdin"]) == 0
+    out = capsys.readouterr().out
+    assert "4111111111111111" not in out
+    assert "[REDACTED:" in out
+
+
+def test_cli_test_profile_input_file(tmp_path, capsys):
+    import redact
+
+    f = tmp_path / "in.txt"
+    f.write_text("card 4111111111111111 here")
+    assert redact._cli(["--test-profile", "pci-dss", "--input", str(f)]) == 0
+    assert "4111111111111111" not in capsys.readouterr().out
+
+
+def test_cli_test_profile_requires_input_source(capsys):
+    import redact
+
+    assert redact._cli(["--test-profile", "pci-dss"]) == 2
+    assert "requires --input" in capsys.readouterr().err
+
+
+def test_redact_iter_redacts_each_item():
+    from redact import redact_iter
+
+    out = redact_iter(["AKIAIOSFODNN7EXAMPLE", "nothing secret"])
+    assert "AKIAIOSFODNN7EXAMPLE" not in out[0]
+    assert out[1] == "nothing secret"


### PR DESCRIPTION
Follow-up from a security review of the Zero-Trust surfaces. Two non-runtime changes; no `lib/` code touched.

## Security docs
Bounds the audit-log claim to what the implementation actually delivers. The hash chain is keyless SHA-256 over a public genesis constant, so it is tamper-evident against in-place edits of individual lines but not end-truncation or a full rewrite. Also notes the macOS keychain key-in-argv exposure (Linux uses stdin) and that the PreToolUse commit gate is an advisory nudge, not an access control. All within the existing threat model.

## Test coverage
Covers three previously under-tested user-facing paths:
- `async_scan_for_revert` - the flagship revert-detection path (async variant), previously uncovered.
- redact profile CLI - `--list-profiles`, `--show-profile` (ok + not-found), `--test-profile` via stdin/file/missing-source.
- Zero-Trust storage round-trip - `append_jsonl` encrypts on disk under an encryption-requesting preset, `read_jsonl` decrypts back, plus the unrecoverable-line skip. The tests mock the keychain and touch no real `security`/`secret-tool` binary.

Lifts telemetry 57->78% and redact 66->90%; full suite 390->402 passing.

`docs/` and `tests/` are outside the integrity manifest, so `MANIFEST.lock` is unchanged.
