### PR TITLE
release v0.8.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "presence",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Continuous-collaboration layer for Claude Code: living project model, outcome telemetry, event digest, and calibrated confidence. Fully local, install-once, applies to every project.",
   "author": {
     "name": "Sara Star Quant LLC"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.8.0
+
+Add an opt-in webhook notifier for confidence-gate verdicts.
+
+`lib/notify.py` can POST confidence-gate verdicts (unhedged-success claims, verified or not) to a webhook URL a user configures locally. Off by default, hard-disabled under `zerotrust` via `network.egress_allowed` (the same gate `update_check` already used), payload redacted before it leaves the machine, and the POST runs in a detached subprocess so a slow or dead endpoint never blocks the Stop hook. `/presence-doctor` gained a notify status line and a confidence-gate catch-rate breakdown by preset.
+
+- `lib/notify.py`: new opt-in webhook notifier, gated on `notify.enabled` + `network.egress_allowed`, redacts string payload fields via `redact.py`, dispatches through a detached subprocess.
+- `lib/doctor.py`: `_notify_summary()` and `_confidence_stats()` (per-preset confidence-gate catch counts, reconstructed from `audit.jsonl`'s `preset_switch` history).
+- `presets/_schema.json`, `presets/zerotrust.json`: `notify` recognized as a schema key, defense-in-depth `notify.enabled: false` under zerotrust.
+- `docs/security.md`, `docs/zerotrust.md`, `docs/recipes.md`, `docs/architecture.md` updated for the new network-egress feature.
+- Dependency bumps: pytest, ruff, coverage, `ext/`'s `serde_json`, and CI's `actions/checkout` / `actions/setup-python` / `actions/cache` to current latest.
+
 ## v0.7.1
 
 Scope the audit-log claim to in-place edits; add test coverage.

--- a/MANIFEST.lock
+++ b/MANIFEST.lock
@@ -2,7 +2,7 @@
   "_format": 1,
   "files": {
     ".claude-plugin/marketplace.json": "066ae0d198f750ebfb7b1df4d1b2dffc3db01030d8c5d5865be0064c007c79ff",
-    ".claude-plugin/plugin.json": "78614bc3778f5de82ff1de55da7f13ce09f732ba388c37c4cb2f9319b9c30e89",
+    ".claude-plugin/plugin.json": "d95bbb6fc24baa2cb448cb0187a7cbf0eabe6fbf5835d7dea90c8097537dbe74",
     "agents/model-curator.md": "1b8381997ea4c29944e1388b7467ca38787c893801e8bfd79460c103d0e169d5",
     "commands/presence-bugreport.md": "dfa35b61dfcf30f0f268fb0c8fed6dbd92f7da058fca34f07b9beab8a52ddf79",
     "commands/presence-curate.md": "9295204486515a9dfd1a66ee77b64b067fdcb04ca436f182106659b33d504986",
@@ -19,7 +19,7 @@
     "hooks/scripts/session-start.sh": "8d1c7ae9ae0884fb88bc9e18f949dc9d5bd1c3ce1aff40da14088128917b09fb",
     "hooks/scripts/stop.sh": "54ead2f0f29aefcf9120f44f99f9c7f5357fbbacc9330d28e942200947595267",
     "hooks/scripts/user-prompt-submit.sh": "006cc582419f061934dc94842de6240722b48ac23578c1b0c84ae1ceaad6df60",
-    "lib/__init__.py": "fe72818954902c750927f99b6391b93debb732e2dc5fb942c3edab61fa06de41",
+    "lib/__init__.py": "754ad6ebb27264692023570d61f6f68d95c848cdc56b8a9fc5a84c1b0d96d527",
     "lib/_common.py": "319b1b10350ee11a73f7c6340e7bd4330f8efea4ced1c29e6b37c63a39a2a19b",
     "lib/audit.py": "d71dada0ad335a0495e17afd04bbcb2f7c6e81fd163d8d3036ba83b5dbc1fa2a",
     "lib/bugreport.py": "6d1f518382e33e032dedff37a4007c7dcc1d7a196100431d86f1d48c36f049fd",

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Stdlib only](https://img.shields.io/badge/runtime-stdlib--only-success)](pyproject.toml)
 [![Local only](https://img.shields.io/badge/state-local--only-success)](docs/security.md)
 
-> **New in [v0.7.0](https://github.com/sara-star-quant/presence/releases/tag/v0.7.0):** relicensed from MIT to Apache-2.0 (still permissive, now with an explicit patent grant). No runtime change.
+> **New in [v0.8.0](https://github.com/sara-star-quant/presence/releases/tag/v0.8.0):** opt-in webhook notifier for confidence-gate verdicts, off by default and hard-disabled under `zerotrust`. See [`docs/recipes.md`](docs/recipes.md).
 
 **Every Claude Code session starts cold. presence makes the next one start where the last one left off.**
 
@@ -55,6 +55,7 @@ The `--build-ext` column reflects optional native acceleration via the Rust daem
 All measurements: macOS arm64, Python 3.14.4. Reproduce locally with `python3 bench/<name>.py --runs N`. See [`bench/README.md`](bench/README.md) for the full convention.
 
 > **Recent changes**: see [`CHANGELOG.md`](CHANGELOG.md) for the full per-version diff.
+> v0.8.0 ships an opt-in webhook notifier for confidence-gate verdicts, gated by the same `network.egress_allowed` zerotrust switch as the release-freshness check.
 > v0.5.0 ships composable redaction profiles for jurisdiction-aware sensitive data. Opt-in via `redact.profiles` in settings: `pii-eu`, `pii-us`, `pci-dss` (PAN matches gated by Luhn). New `docs/compliance.md` says exactly what presence does and does not do for regulated workloads. No certification framing: profile names describe data classes, not compliance frameworks.
 > v0.4.2 ships the cross-tool AGENTS.md adapter. Set `PRESENCE_HOST=agents-md` and presence refreshes `<repo>/AGENTS.md` on every Claude Code SessionStart, picked up automatically by Codex, Cursor, Gemini CLI, Windsurf, GitHub Copilot, and others reading the open AGENTS.md standard. See [`docs/multi-host.md`](docs/multi-host.md).
 > v0.4.1 shipped the MCP server: any MCP-aware client (Claude Desktop, Cursor, Continue, custom agents) can read presence's living model + outcome telemetry over JSON-RPC stdio. See [`docs/mcp.md`](docs/mcp.md).

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -1,5 +1,5 @@
 """presence: continuous-collaboration layer for Claude Code."""
-__version__ = "0.7.0"
+__version__ = "0.8.0"
 
 # Lower bound on the compiled presence_ext crate version that this Python
 # plugin expects. Bumped manually whenever a Python-side change requires a


### PR DESCRIPTION
- notify.py: opt-in webhook notifier for confidence-gate verdicts. Off by default, hard-disabled under zerotrust, payload redacted, dispatched via detached subprocess.
- doctor.py: notify status line + confidence-gate catch-rate breakdown by preset.
- presets/_schema.json, presets/zerotrust.json: notify recognized, off under zerotrust.
- docs updated for the notify feature.
- deps: pytest, ruff, coverage, serde_json, GH actions to latest.